### PR TITLE
fix List.of jackson can not be serialized bug

### DIFF
--- a/fluxcache-core/src/main/java/com/fluxcache/core/caffeine/FluxCaffeineCache.java
+++ b/fluxcache-core/src/main/java/com/fluxcache/core/caffeine/FluxCaffeineCache.java
@@ -9,6 +9,7 @@ import com.fluxcache.core.monitor.FluxCacheMonitor;
 import com.fluxcache.core.properties.FluxCacheProperties;
 import com.fluxcache.core.utils.JsonUtil;
 import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.google.common.collect.Lists;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -219,7 +220,7 @@ public class FluxCaffeineCache<K, V> extends FluxAbstractValueAdaptingCache<K, V
      * 分布式删除缓存
      */
     protected void postEvict(K key) {
-        DeleteCacheDTO deleteCacheDTO = new DeleteCacheDTO(this.name, List.of(key));
+        DeleteCacheDTO deleteCacheDTO = new DeleteCacheDTO(this.name, Lists.newArrayList(key));
         deleteCacheDTO.setTopicName(deleteCacheDTO.topicName(fluxCacheProperties.namespace()));
         cacheSyncStrategy.postEvict(deleteCacheDTO);
     }


### PR DESCRIPTION
https://github.com/weihubeats/fluxcache/issues/1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Compatibility**
	- Updated list creation method to improve Java version compatibility
	- Replaced Java 9-specific `List.of()` with Guava library's list creation method

<!-- end of auto-generated comment: release notes by coderabbit.ai -->