### PR TITLE
add Whether to cache null is configurable

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -28,7 +28,7 @@ jobs:
 
       # 缓存 Maven 依赖
       - name: Cache Maven Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/fluxcache-core/src/main/java/com/fluxcache/core/FluxCache.java
+++ b/fluxcache-core/src/main/java/com/fluxcache/core/FluxCache.java
@@ -79,6 +79,12 @@ public interface FluxCache<K, V> extends LocalCache<K, V> {
         return false;
     }
 
+    /**
+     * 是否缓存null
+     * @return
+     */
+    boolean allowCacheNull();
+
     @FunctionalInterface
     interface ValueWrapper<V> {
 

--- a/fluxcache-core/src/main/java/com/fluxcache/core/annotation/FluxCacheable.java
+++ b/fluxcache-core/src/main/java/com/fluxcache/core/annotation/FluxCacheable.java
@@ -29,6 +29,8 @@ public @interface FluxCacheable {
 
     String key() default "";
 
+    boolean allowCacheNull() default true;
+
     FirstCacheable firstCacheable() default @FirstCacheable();
 
 

--- a/fluxcache-core/src/main/java/com/fluxcache/core/annotation/FluxSpringCacheAnnotationParser.java
+++ b/fluxcache-core/src/main/java/com/fluxcache/core/annotation/FluxSpringCacheAnnotationParser.java
@@ -107,6 +107,7 @@ public class FluxSpringCacheAnnotationParser implements FluxCacheAnnotationParse
         FluxCacheOperation fluxCacheOperation = new FluxMultilevelCacheCacheable.Builder()
             .setFirstCacheConfig(firstCacheConfig)
             .setSecondaryCacheable(secondaryCacheable)
+            .setAllowNullValues(ca.allowCacheNull())
             .setFluxCacheLevel(cacheLevel)
             .setCacheName(ca.cacheName())
             .setMethodName(ae.toString())

--- a/fluxcache-core/src/main/java/com/fluxcache/core/annotation/FluxSpringCacheAnnotationParser.java
+++ b/fluxcache-core/src/main/java/com/fluxcache/core/annotation/FluxSpringCacheAnnotationParser.java
@@ -107,7 +107,7 @@ public class FluxSpringCacheAnnotationParser implements FluxCacheAnnotationParse
         FluxCacheOperation fluxCacheOperation = new FluxMultilevelCacheCacheable.Builder()
             .setFirstCacheConfig(firstCacheConfig)
             .setSecondaryCacheable(secondaryCacheable)
-            .setAllowNullValues(ca.allowCacheNull())
+            .setAllowCacheNull(ca.allowCacheNull())
             .setFluxCacheLevel(cacheLevel)
             .setCacheName(ca.cacheName())
             .setMethodName(ae.toString())

--- a/fluxcache-core/src/main/java/com/fluxcache/core/caffeine/FluxCaffeineCache.java
+++ b/fluxcache-core/src/main/java/com/fluxcache/core/caffeine/FluxCaffeineCache.java
@@ -47,14 +47,14 @@ public class FluxCaffeineCache<K, V> extends FluxAbstractValueAdaptingCache<K, V
     /**
      * @param name            the name of the cache
      * @param cache           the backing Caffeine Cache instance
-     * @param allowNullValues whether to accept and convert {@code null}
-     *                        values for this cache
+     * @param allowCacheNull 
+     *                       
      */
     public FluxCaffeineCache(String name, com.github.benmanes.caffeine.cache.Cache cache,
-        boolean allowNullValues, CacheSyncStrategy cacheSyncStrategy, FluxCacheProperties cacheProperties,
+        boolean allowCacheNull, CacheSyncStrategy cacheSyncStrategy, FluxCacheProperties cacheProperties,
         FluxCacheMonitor cacheMonitor) {
 
-        super(allowNullValues, cacheMonitor, name, cacheProperties);
+        super(allowCacheNull, cacheMonitor, name, cacheProperties);
         Assert.notNull(name, "Name must not be null");
         Assert.notNull(cache, "Cache must not be null");
         this.cache = cache;

--- a/fluxcache-core/src/main/java/com/fluxcache/core/impl/FluxCacheFactory.java
+++ b/fluxcache-core/src/main/java/com/fluxcache/core/impl/FluxCacheFactory.java
@@ -43,7 +43,7 @@ public class FluxCacheFactory {
             FluxAbstractValueAdaptingCache<?, ?> FluxFirstCache = CacheTypeStrategy.getStrategy(secondaryCacheConfig.getCacheType()).createFluxCache(cacheCacheable, redissonClient, cacheSyncStrategy, cacheProperties, cacheMonitor);
             FluxAbstractValueAdaptingCache<?, ?> FluxSecondaryCache = CacheTypeStrategy.getStrategy(config.getCacheType()).createFluxCache(cacheCacheable, redissonClient, cacheSyncStrategy, cacheProperties, cacheMonitor);
 
-            FluxRedissonCaffeineCache<?, ?> cache = new FluxRedissonCaffeineCache(true, ca.getCacheName(), FluxFirstCache, FluxSecondaryCache, cacheMonitor, cacheProperties);
+            FluxRedissonCaffeineCache<?, ?> cache = new FluxRedissonCaffeineCache(ca.isAllowCacheNull(), ca.getCacheName(), FluxFirstCache, FluxSecondaryCache, cacheMonitor, cacheProperties);
             return cache;
         }
         return null;
@@ -63,7 +63,7 @@ public class FluxCacheFactory {
                     .initialCapacity(ca.getInitSize())
                     .maximumSize(ca.getMaxSize())
                     .build();
-                return new FluxCaffeineCache<>(ca.getCacheName(), caffeineCache, cacheSyncStrategy, cacheProperties, cacheMonitor);
+                return new FluxCaffeineCache<>(ca.getCacheName(), caffeineCache, ca.isAllowCacheNull(),  cacheSyncStrategy, cacheProperties, cacheMonitor);
             }
         },
         REDIS(FluxCacheType.REDIS_R_MAP) {
@@ -72,7 +72,7 @@ public class FluxCacheFactory {
                 RedissonClient redissonClient,
                 CacheSyncStrategy cacheSyncStrategy, FluxCacheProperties cacheProperties,
                 FluxCacheMonitor cacheMonitor) {
-                return new FluxRedissonCacheByRMapCache<>(true, redissonClient, ca, cacheMonitor, cacheProperties);
+                return new FluxRedissonCacheByRMapCache<>(ca.isAllowCacheNull(), redissonClient, ca, cacheMonitor, cacheProperties);
             }
         },
         REDIS_BUCKET(FluxCacheType.REDIS_BUCKET) {
@@ -81,7 +81,7 @@ public class FluxCacheFactory {
                 RedissonClient redissonClient,
                 CacheSyncStrategy cacheSyncStrategy, FluxCacheProperties cacheProperties,
                 FluxCacheMonitor cacheMonitor) {
-                return new FluxRedissonCacheByBucket<>(true, redissonClient, ca, cacheMonitor, cacheProperties);
+                return new FluxRedissonCacheByBucket<>(ca.isAllowCacheNull(), redissonClient, ca, cacheMonitor, cacheProperties);
             }
         };
 

--- a/fluxcache-core/src/main/java/com/fluxcache/core/impl/FluxRedissonCaffeineCache.java
+++ b/fluxcache-core/src/main/java/com/fluxcache/core/impl/FluxRedissonCaffeineCache.java
@@ -26,12 +26,12 @@ public class FluxRedissonCaffeineCache<K, V> extends FluxAbstractValueAdaptingCa
     /**
      * Create an {@code AbstractValueAdaptingCache} with the given setting.
      *
-     * @param allowNullValues whether to allow for {@code null} values
+     * @param allowCacheNull 
      */
-    protected FluxRedissonCaffeineCache(boolean allowNullValues, String name,
+    protected FluxRedissonCaffeineCache(boolean allowCacheNull, String name,
         FluxAbstractValueAdaptingCache<K, V> fluxFirstCache, FluxAbstractValueAdaptingCache<K, V> fluxSecondaryCache,
         FluxCacheMonitor cacheMonitor, FluxCacheProperties cacheProperties) {
-        super(allowNullValues, cacheMonitor, name, cacheProperties);
+        super(allowCacheNull, cacheMonitor, name, cacheProperties);
         this.fluxFirstCache = fluxFirstCache;
         this.fluxSecondaryCache = fluxSecondaryCache;
     }

--- a/fluxcache-core/src/main/java/com/fluxcache/core/model/FluxCacheCacheable.java
+++ b/fluxcache-core/src/main/java/com/fluxcache/core/model/FluxCacheCacheable.java
@@ -19,12 +19,15 @@ public class FluxCacheCacheable extends FluxCacheOperation{
 
     private final int maxSize;
 
+    private final boolean allowCacheNull;
+
     public FluxCacheCacheable(Builder b) {
         super(b);
         this.ttl = b.ttl;
         this.initSize = b.initSize;
         this.unit = b.unit;
         this.maxSize = b.maxSize;
+        this.allowCacheNull = b.allowCacheNull;
     }
 
     public static class Builder extends FluxCacheOperation.Builder {
@@ -36,6 +39,8 @@ public class FluxCacheCacheable extends FluxCacheOperation{
         private TimeUnit unit;
 
         private int maxSize;
+
+        private boolean allowCacheNull;
 
         public FluxCacheCacheable.Builder setTtl(Long ttl) {
             this.ttl = ttl;
@@ -54,6 +59,11 @@ public class FluxCacheCacheable extends FluxCacheOperation{
 
         public FluxCacheCacheable.Builder setMaxSize(int maxSize) {
             this.maxSize = maxSize;
+            return this;
+        }
+
+        public FluxCacheCacheable.Builder setAllowCacheNull(boolean allowCacheNull) {
+            this.allowCacheNull = allowCacheNull;
             return this;
         }
 

--- a/fluxcache-core/src/main/java/com/fluxcache/core/model/FluxMultilevelCacheCacheable.java
+++ b/fluxcache-core/src/main/java/com/fluxcache/core/model/FluxMultilevelCacheCacheable.java
@@ -15,16 +15,20 @@ public class FluxMultilevelCacheCacheable extends FluxCacheOperation {
 
     private final FluxCacheCacheableConfig secondaryCacheConfig;
 
+    private final boolean allowCacheNull;
+
     public FluxMultilevelCacheCacheable(Builder builder) {
         super(builder);
         this.firstCacheConfig = builder.firstCacheConfig;
         this.secondaryCacheConfig = builder.secondaryCacheConfig;
+        this.allowCacheNull = builder.allowNullValues;
     }
 
     public FluxMultilevelCacheCacheable(CacheConfigBuilder builder) {
         super(builder.cacheName, builder.fluxCacheLevel);
         this.firstCacheConfig = builder.firstCacheConfig;
         this.secondaryCacheConfig = builder.secondaryCacheConfig;
+        this.allowCacheNull = builder.allowNullValues;
     }
 
     public FluxCacheOperation convertsFluxCacheCacheable(FluxCacheCacheableConfig cacheableConfig) {
@@ -34,6 +38,7 @@ public class FluxMultilevelCacheCacheable extends FluxCacheOperation {
             .setTtl(cacheableConfig.getTtl())
             .setInitSize(cacheableConfig.getInitSize())
             .setMaxSize(cacheableConfig.getMaxSize())
+            .setAllowCacheNull(this.isAllowCacheNull())
             .setCacheName(this.getCacheName())
             .setKey(this.getKey())
             .setMethodName(this.getMethodName())
@@ -46,6 +51,8 @@ public class FluxMultilevelCacheCacheable extends FluxCacheOperation {
 
         private FluxCacheCacheableConfig secondaryCacheConfig;
 
+        private boolean allowNullValues;
+
         public Builder setFirstCacheConfig(FluxCacheCacheableConfig firstCacheConfig) {
             this.firstCacheConfig = firstCacheConfig;
             return this;
@@ -53,6 +60,11 @@ public class FluxMultilevelCacheCacheable extends FluxCacheOperation {
 
         public Builder setSecondaryCacheable(FluxCacheCacheableConfig secondaryCacheConfig) {
             this.secondaryCacheConfig = secondaryCacheConfig;
+            return this;
+        }
+
+        public Builder setAllowNullValues(boolean allowNullValues) {
+            this.allowNullValues = allowNullValues;
             return this;
         }
 
@@ -75,6 +87,8 @@ public class FluxMultilevelCacheCacheable extends FluxCacheOperation {
 
         private FluxCacheCacheableConfig secondaryCacheConfig;
 
+        private boolean allowNullValues;
+
         public CacheConfigBuilder setCacheName(String cacheName) {
             this.cacheName = cacheName;
             return this;
@@ -92,6 +106,11 @@ public class FluxMultilevelCacheCacheable extends FluxCacheOperation {
 
         public CacheConfigBuilder setSecondaryCacheConfig(FluxCacheCacheableConfig secondaryCacheConfig) {
             this.secondaryCacheConfig = secondaryCacheConfig;
+            return this;
+        }
+
+        public CacheConfigBuilder setAllowNullValues(boolean allowNullValues) {
+            this.allowNullValues = allowNullValues;
             return this;
         }
 

--- a/fluxcache-core/src/main/java/com/fluxcache/core/model/FluxMultilevelCacheCacheable.java
+++ b/fluxcache-core/src/main/java/com/fluxcache/core/model/FluxMultilevelCacheCacheable.java
@@ -38,7 +38,7 @@ public class FluxMultilevelCacheCacheable extends FluxCacheOperation {
             .setTtl(cacheableConfig.getTtl())
             .setInitSize(cacheableConfig.getInitSize())
             .setMaxSize(cacheableConfig.getMaxSize())
-            .setAllowCacheNull(this.isAllowCacheNull())
+            .setAllowCacheNull(this.allowCacheNull)
             .setCacheName(this.getCacheName())
             .setKey(this.getKey())
             .setMethodName(this.getMethodName())
@@ -63,8 +63,8 @@ public class FluxMultilevelCacheCacheable extends FluxCacheOperation {
             return this;
         }
 
-        public Builder setAllowNullValues(boolean allowNullValues) {
-            this.allowNullValues = allowNullValues;
+        public Builder setAllowCacheNull(boolean allowCacheNull) {
+            this.allowNullValues = allowCacheNull;
             return this;
         }
 

--- a/fluxcache-example/src/main/java/com/fluxcache/example/controller/TestController.java
+++ b/fluxcache-example/src/main/java/com/fluxcache/example/controller/TestController.java
@@ -182,6 +182,19 @@ public class TestController {
         return mockSelectSqlToNull();
     }
 
+    /**
+     * 不缓存null
+     * @param name
+     * @return
+     */
+    @GetMapping("/test-no-null-firstCache")
+    @FluxCacheable(cacheName = "testNoNullFirstCache", key = "#name",
+        fluxCacheLevel = FluxCacheLevel.FirstCacheable,
+        firstCacheable = @FirstCacheable(fluxCacheType = FluxCacheType.CAFFEINE, ttl = 5L, unit = TimeUnit.MINUTES, maxSize = 2000, initSize = 20), allowCacheNull = false)
+    public List<StudentVO> mockSelectSqlToNoNullByFirstCache(String name) {
+        return mockSelectSqlToNull();
+    }
+
     @GetMapping("/test-null-secondaryCache")
     @FluxCacheable(cacheName = "testNullSecondaryCache", key = "#name",
         fluxCacheLevel = FluxCacheLevel.SecondaryCacheable,

--- a/fluxcache-example/src/test/java/com/fluxcache/example/controller/TestControllerTest.java
+++ b/fluxcache-example/src/test/java/com/fluxcache/example/controller/TestControllerTest.java
@@ -79,6 +79,12 @@ public class TestControllerTest {
     }
 
     @Test
+    public void testFirstCacheByCaffeineByNoNull() {
+        List<StudentVO> vos = testController.mockSelectSqlToNoNullByFirstCache("orderNull");
+        List<StudentVO> vos1 = testController.mockSelectSqlToNoNullByFirstCache("orderNull");
+    }
+
+    @Test
     public void firstCacheByCaffeineAndOptional() {
         String key = "orderOptional";
         Optional<List<StudentVO>> vosOptionals = testController.firstCacheByCaffeineAndOptional(key);


### PR DESCRIPTION
https://github.com/weihubeats/fluxcache/issues/11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring whether null values are allowed to be cached via a new option in cache annotations.
  - Introduced a new API endpoint demonstrating disabling null value caching.
- **Bug Fixes**
  - Improved handling to prevent caching of null values when this option is disabled.
- **Tests**
  - Added a test to verify behavior when null values are not cached.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->