### PR TITLE
 add cache preheat

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,59 @@ public class MyFluxCacheDataRegistered implements FluxCacheDataRegistered {
 }
 ```
 
+## 缓存刷新
+
+如果需要定时刷新缓存,可以使用`@FluxRefresh`注解
+
+```java
+    @Override
+    @FluxCacheable(
+        cacheName = "testRefreshCache",
+        key = "'all'",
+        refresh = @FluxRefresh(
+            enabled = true,
+            provider = StudentProvider.class,
+            cron = "0/2 * * * * ?" // 0 */1 * * * ? 一分钟
+        )
+    )
+```
+
+`provider`需要实现`FluxPreheatDataProvider`接口，然后提供自己需要刷新缓存的key,并注入spring容器
+
+```java
+@Service
+public class StudentProvider implements FluxPreheatDataProvider<String> {
+    
+    
+    @Override
+    public Collection<String> getPreheatData() {
+        return List.of("all");
+    }
+}
+
+```
+
+如果需要开启缓存预热
+使用`preheatOnStartup = true,`即可
+
+```java
+    @Override
+@FluxCacheable(
+    cacheName = "multipleKeys",
+    key = "#name",
+    refresh = @FluxRefresh(
+        enabled = true,
+        provider = StudentMultipleKeysProvider.class,
+        preheatOnStartup = true,
+        cron = "0 */1 * * * ?" // 1分钟刷新一次
+    )
+)
+public List<StudentVO> multipleKeys(String name) {
+    log.info("开始查询数据");
+    return randomStudents(name);
+}
+```
+
 ## 内置缓存管理接口
 
 默认同意请求前缀为`/cache/manager/v1`，详细接口返回情况可以查看[FluxCacheController.java](fluxcache-admin%2Fsrc%2Fmain%2Fjava%2Fcom%2Ffluxcache%2Fadmin%2Fcontroller%2FFluxCacheController.java)

--- a/fluxcache-admin/src/main/java/com/fluxcache/admin/vo/FluxCacheStaticsVO.java
+++ b/fluxcache-admin/src/main/java/com/fluxcache/admin/vo/FluxCacheStaticsVO.java
@@ -1,7 +1,5 @@
 package com.fluxcache.admin.vo;
 
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.LongAdder;
 import lombok.Data;
 
 /**
@@ -12,48 +10,24 @@ import lombok.Data;
 @Data
 public class FluxCacheStaticsVO {
 
-    /**
-     * 命中次数
-     */
-    private LongAdder hit;
+    private long startTime;
+
+    private long endTime;
+
+    private long hit;
+
+    private long miss;
+
+    private long putCount;
+
+    private long evictCount;
+
+    private long requestCount;
 
     /**
-     * 失败次数
+     *  ms，窗口内最大加载耗时
      */
-    private LongAdder fail;
-
-    /**
-     * 删除次数
-     */
-    private LongAdder evictCount;
-
-    /**
-     * 缓存的put次数
-     */
-    private LongAdder putCount;
-
-    /**
-     * 请求次数
-     */
-    private LongAdder requestCount;
-
-    /**
-     * 最大加载时间
-     */
-    private AtomicLong maxLoadTime;
-
-    /**
-     * 命中率
-     */
-    private Double hitRate;
-
-    /**
-     * 开始时间
-     */
-    private Long startTime;
-
-    /**
-     * 结束时间
-     */
-    private Long endTime;
+    private long maxLoadTime;
+    
+    private double hitRate;
 }

--- a/fluxcache-admin/src/main/java/com/fluxcache/admin/vo/FluxCacheStatsAssembler.java
+++ b/fluxcache-admin/src/main/java/com/fluxcache/admin/vo/FluxCacheStatsAssembler.java
@@ -1,0 +1,129 @@
+package com.fluxcache.admin.vo;
+
+import com.fluxcache.core.monitor.FluxCacheInfo;
+import com.fluxcache.core.monitor.FluxCacheStatics;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * @author : wh
+ * @date : 2025/9/16 14:02
+ * @description:
+ */
+public class FluxCacheStatsAssembler {
+
+    /**
+     * 从 FluxCacheStatics 生成 VO，支持截取最近 N 个窗口
+     */
+    public static void fill(FluxCacheAllStaticsVO out,
+                            String cacheName,
+                            FluxCacheStatics statics,
+                            int lastNWindows) {
+        if (out == null || statics == null)
+            return;
+
+        out.setCacheName(cacheName);
+        out.setStartTime(statics.getStartTime());
+
+        // 做一份窗口快照，避免遍历过程中窗口滚动导致的不一致
+        List<FluxCacheInfo> snapshot = snapshot(statics);
+        // 只保留最后 N 个窗口
+        if (lastNWindows > 0 && snapshot.size() > lastNWindows) {
+            snapshot = snapshot.subList(snapshot.size() - lastNWindows, snapshot.size());
+        }
+        fill(out, cacheName, statics.getStartTime(), snapshot);
+    }
+
+    public static void fill(FluxCacheAllStaticsVO out,
+                            String cacheName,
+                            long startTime,
+                            List<FluxCacheInfo> buckets) {
+        if (out == null || buckets == null)
+            return;
+
+        out.setCacheName(cacheName);
+        out.setStartTime(startTime);
+
+        List<FluxCacheStaticsVO> windows = new ArrayList<>(buckets.size());
+
+        long totalHit = 0L;
+        long totalMiss = 0L;
+        long totalPut = 0L;
+        long totalEvict = 0L;
+        long totalReq = 0L;
+        long maxLoadTimeOverall = 0L;
+
+        long now = System.currentTimeMillis();
+
+        for (FluxCacheInfo info : buckets) {
+            long hit = info.getHit().sum();
+            long miss = info.getFail().sum();
+            long put = info.getPutCount().sum();
+            long evict = info.getEvictCount().sum();
+            long req = info.getRequestCount().sum();
+            long maxLoad = info.getMaxLoadTime().get();
+
+            long start = info.getStartTime().get();
+            long end = info.getEndTime().get();
+            // 展示用的 endTime 不要超过当前时间（最后一个窗口的 end 可能在未来）
+            long displayEnd = Math.min(end, now);
+
+            double hitRate = calcRate(hit, req);
+
+            FluxCacheStaticsVO vo = new FluxCacheStaticsVO();
+            vo.setStartTime(start);
+            vo.setEndTime(displayEnd);
+            vo.setHit(hit);
+            vo.setMiss(miss);
+            vo.setPutCount(put);
+            vo.setEvictCount(evict);
+            vo.setRequestCount(req);
+            vo.setMaxLoadTime(Math.max(0L, maxLoad));
+            vo.setHitRate(hitRate);
+
+            windows.add(vo);
+
+            totalHit += hit;
+            totalMiss += miss;
+            totalPut += put;
+            totalEvict += evict;
+            totalReq += req;
+            maxLoadTimeOverall = Math.max(maxLoadTimeOverall, Math.max(0L, maxLoad));
+        }
+
+        out.setWindows(windows);
+        out.setTotalHit(totalHit);
+        out.setTotalMiss(totalMiss);
+        out.setTotalPut(totalPut);
+        out.setTotalEvict(totalEvict);
+        out.setTotalRequest(totalReq);
+        out.setMaxLoadTimeOverall(maxLoadTimeOverall);
+        out.setOverallHitRate(calcRate(totalHit, totalReq));
+    }
+
+    private static double calcRate(long numerator, long denominator) {
+        if (denominator <= 0)
+            return 0.0;
+        // 保留 4 位小数，四舍五入
+        return BigDecimal.valueOf((double) numerator / (double) denominator)
+                .setScale(4, RoundingMode.HALF_UP)
+                .doubleValue();
+    }
+
+    /**
+     * 复制一个安全快照（从旧到新）
+     */
+    private static List<FluxCacheInfo> snapshot(FluxCacheStatics statics) {
+        // ConcurrentLinkedDeque 支持弱一致迭代，这里简单拷贝一份
+        List<FluxCacheInfo> list = new ArrayList<>(statics.getWindow().size());
+        Iterator<FluxCacheInfo> it = statics.getWindow().iterator();
+        while (it.hasNext()) {
+            list.add(it.next());
+        }
+        return list;
+    }
+}

--- a/fluxcache-core/src/main/java/com/fluxcache/core/DefaultFluxCacheManager.java
+++ b/fluxcache-core/src/main/java/com/fluxcache/core/DefaultFluxCacheManager.java
@@ -7,8 +7,18 @@ import com.fluxcache.core.interceptor.FluxCacheOperationSource;
 import com.fluxcache.core.model.FluxCacheOperation;
 import com.fluxcache.core.model.FluxMultilevelCacheCacheable;
 import com.fluxcache.core.monitor.FluxCacheMonitor;
+import com.fluxcache.core.monitor.FluxCacheMonitorEvent;
 import com.fluxcache.core.monitor.FluxCacheStatics;
+import com.fluxcache.core.monitor.MonitorEventEnum;
 import com.fluxcache.core.properties.FluxCacheProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RedissonClient;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.util.ReflectionUtils;
+
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
@@ -16,14 +26,6 @@ import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.redisson.api.RedissonClient;
-import org.springframework.aop.support.AopUtils;
-import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.config.BeanPostProcessor;
-import org.springframework.util.ObjectUtils;
-import org.springframework.util.ReflectionUtils;
 
 /**
  * @author : wh
@@ -42,7 +44,7 @@ public class DefaultFluxCacheManager implements FluxCacheManager, BeanPostProces
     /**
      * cache metaData
      */
-    private final ConcurrentMap<String, FluxCacheOperation> FluxCacheMetaData = new ConcurrentHashMap<>(16);
+    private final ConcurrentMap<String, FluxCacheOperation> fluxCacheMetaData = new ConcurrentHashMap<>(16);
 
     private final RedissonClient redissonClient;
 
@@ -58,7 +60,11 @@ public class DefaultFluxCacheManager implements FluxCacheManager, BeanPostProces
     public void createCache(FluxMultilevelCacheCacheable cacheable) {
         FluxCache<?, ?> cache = FluxCacheFactory.createFluxCache(cacheable, redissonClient, cacheProperties, cacheSyncStrategy, fluxCacheMonitor);
         cacheMap.put(cacheable.getCacheName(), cache);
-        FluxCacheMetaData.put(cacheable.getCacheName(), cacheable);
+        fluxCacheMetaData.put(cacheable.getCacheName(), cacheable);
+        if (cacheProperties.isCacheMonitorEnable()) {
+            fluxCacheMonitor.createNewCacheStatics(cacheable.getCacheName());
+        }
+        log.info("create cacheName {}", cacheable.getCacheName());
     }
 
     @Override
@@ -67,31 +73,52 @@ public class DefaultFluxCacheManager implements FluxCacheManager, BeanPostProces
         return (FluxCache<K, V>) cacheMap.get(cacheName);
     }
 
-
     @Override
     @SuppressWarnings("unchecked")
     public <K, V> V getCacheOrPut(String cacheName, K key, Callable<V> valueLoader) {
         FluxCache<K, V> cache = cacheMap.get(cacheName);
-        V cacheValue = null;
-        if (Objects.nonNull(cache)) {
-            V t = cache.get(key, valueLoader);
-            if (ObjectUtils.isEmpty(t)) {
-                try {
-                    cacheValue = valueLoader.call();
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
-                cache.put(key, cacheValue);
-            } else {
-                return t;
+        if (Objects.isNull(cache)) {
+            // 无缓存实例：直接加载并返回（不统计）
+            try {
+                return valueLoader.call();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
             }
         }
-        return cacheValue;
+
+        // 先尝试命中
+        try {
+            FluxCache.ValueWrapper wrapper = cache.get(key);
+            if (wrapper != null) {
+                publish(cacheName, MonitorEventEnum.CACHE_HIT, keyToString(key), 1L, 0L);
+                return (V) wrapper.get();
+            }
+        } catch (Exception getEx) {
+            log.error("cache.get error cache={} key={}", cacheName, key, getEx);
+            // 视为 miss 继续加载
+        }
+
+        // 未命中 -> 加载 & 写入
+        publish(cacheName, MonitorEventEnum.CACHE_MISSING, keyToString(key), 1L, 0L);
+
+        long begin = System.nanoTime();
+        V value;
+        try {
+            value = valueLoader.call();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        long loadMs = (System.nanoTime() - begin) / 1_000_000;
+
+        cache.put(key, value);
+        publish(cacheName, MonitorEventEnum.CACHE_PUT, keyToString(key), 1L, loadMs);
+        return value;
     }
 
     @Override
     public <K, V> boolean putCache(String key, FluxCache<K, V> cache) {
         cacheMap.put(key, cache);
+        publish(cache.getName(), MonitorEventEnum.CACHE_PUT, key, 1L, 0L);
         return true;
     }
 
@@ -107,6 +134,7 @@ public class DefaultFluxCacheManager implements FluxCacheManager, BeanPostProces
             return false;
         }
         cache.bathEvict(keys);
+        publish(cacheName, MonitorEventEnum.CACHE_EVICT, "*", keys != null ? keys.size() : 0L, 0L);
         log.info("evict cache key {}", keys);
         return true;
     }
@@ -118,18 +146,19 @@ public class DefaultFluxCacheManager implements FluxCacheManager, BeanPostProces
             return false;
         }
         cache.clear();
+        publish(cacheName, MonitorEventEnum.CACHE_EVICT, "*", 1L, 0L);
         log.info("clear cache name {}", cacheName);
         return true;
     }
 
     @Override
     public FluxCacheOperation getCacheMetaData(String cacheName) {
-        return FluxCacheMetaData.get(cacheName);
+        return fluxCacheMetaData.get(cacheName);
     }
 
     @Override
     public List<FluxCacheOperation> getAllCacheMetaData() {
-        return new ArrayList<>(FluxCacheMetaData.values());
+        return new ArrayList<>(fluxCacheMetaData.values());
     }
 
     @Override
@@ -140,15 +169,18 @@ public class DefaultFluxCacheManager implements FluxCacheManager, BeanPostProces
     public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
         Method[] methods = ReflectionUtils.getAllDeclaredMethods(AopUtils.getTargetClass(bean));
         for (Method method : methods) {
-            FluxCacheOperation FluxCacheOperation = fluxCacheOperationSource.getCacheOperation(method, bean.getClass());
-            if (Objects.nonNull(FluxCacheOperation) && FluxCacheOperation instanceof FluxMultilevelCacheCacheable) {
-                FluxMultilevelCacheCacheable ca = (FluxMultilevelCacheCacheable) FluxCacheOperation;
-                if (!cacheMap.containsKey(FluxCacheOperation.getCacheName())) {
+            FluxCacheOperation op = fluxCacheOperationSource.getCacheOperation(method, bean.getClass());
+            if (Objects.nonNull(op) && op instanceof FluxMultilevelCacheCacheable) {
+                FluxMultilevelCacheCacheable ca = (FluxMultilevelCacheCacheable) op;
+                if (!cacheMap.containsKey(op.getCacheName())) {
                     // 相同缓存名 只能有一个元数据
                     FluxCache cache = FluxCacheFactory.createFluxCache(ca, redissonClient, cacheProperties, cacheSyncStrategy, fluxCacheMonitor);
                     log.info("create cacheName {}", ca.getCacheName());
-                    cacheMap.put(FluxCacheOperation.getCacheName(), cache);
-                    FluxCacheMetaData.put(FluxCacheOperation.getCacheName(), FluxCacheOperation);
+                    cacheMap.put(op.getCacheName(), cache);
+                    fluxCacheMetaData.put(op.getCacheName(), op);
+                    if (cacheProperties.isCacheMonitorEnable()) {
+                        fluxCacheMonitor.createNewCacheStatics(op.getCacheName());
+                    }
 
                 } else {
                     log.warn("Metadata with the same cache name already exists, cache Name {}", ca.getCacheName());
@@ -158,8 +190,42 @@ public class DefaultFluxCacheManager implements FluxCacheManager, BeanPostProces
             }
         }
         if (cacheProperties.isCacheMonitorEnable()) {
-            fluxCacheMonitor.createCacheStaticsMap(FluxCacheMetaData);
+            fluxCacheMonitor.createCacheStaticsMap(fluxCacheMetaData);
         }
         return bean;
+    }
+
+    private String keyToString(Object key) {
+        if (key == null)
+            return "null";
+        try {
+            String s = String.valueOf(key);
+            // 如需脱敏可在此处理
+            return s.length() > 256 ? s.substring(0, 256) : s;
+        } catch (Exception e) {
+            return key.getClass().getName();
+        }
+    }
+
+    private void publish(String cacheName, MonitorEventEnum type, String key, long count, long loadMs) {
+        if (cacheProperties.isCacheMonitorEnable()) {
+            try {
+                fluxCacheMonitor.publishMonitorEvent(
+                        FluxCacheMonitorEvent.builder()
+                                .cacheName(cacheName)
+                                .monitorEventEnum(type)
+                                .count(count)
+                                .loadTime(loadMs)
+                                .timestamp(System.currentTimeMillis())
+                                .key(key)
+                                .forceRefresh(false)
+                                .build()
+                );
+            } catch (Exception e) {
+                log.warn("publish monitor event failed cache={} type={} key={}", cacheName, type, key, e);
+            }
+
+        }
+
     }
 }

--- a/fluxcache-core/src/main/java/com/fluxcache/core/annotation/FluxCacheable.java
+++ b/fluxcache-core/src/main/java/com/fluxcache/core/annotation/FluxCacheable.java
@@ -1,13 +1,14 @@
 package com.fluxcache.core.annotation;
 
 import com.fluxcache.core.enums.FluxCacheLevel;
+import org.springframework.core.annotation.AliasFor;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.core.annotation.AliasFor;
 
 /**
  * @author : wh
@@ -41,5 +42,10 @@ public @interface FluxCacheable {
      * @return
      */
     FluxCacheLevel fluxCacheLevel() default FluxCacheLevel.NULL;
+
+    /**
+     * 配置缓存定时刷新功能
+     */
+    FluxRefresh refresh() default @FluxRefresh();
 
 }

--- a/fluxcache-core/src/main/java/com/fluxcache/core/annotation/FluxRefresh.java
+++ b/fluxcache-core/src/main/java/com/fluxcache/core/annotation/FluxRefresh.java
@@ -1,0 +1,93 @@
+package com.fluxcache.core.annotation;
+
+import com.fluxcache.core.preheat.FluxPreheatDataProvider;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author : wh
+ * @date : 2025/9/16 14:10
+ * @description:
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface FluxRefresh {
+
+    /**
+     * 是否开启缓存定时刷新
+     * @return
+     */
+    boolean enabled() default false;
+
+
+    /**
+     * 用于获取刷新所需数据的提供者。
+     * 复用 PreheatDataProvider 接口。
+     */
+    Class<? extends FluxPreheatDataProvider> provider() default FluxPreheatDataProvider.None.class;
+
+    /**
+     * CRON表达式，用于定义刷新周期。
+     * cron 优先级高于 fixedRate/fixedDelay。
+     * @return
+     */
+    String cron() default "";
+
+    /**
+     * 固定频率执行的间隔时间。
+     * 单位由 unit() 定义。
+     */
+    long fixedRate() default -1L;
+
+    /**
+     * 固定延迟执行的间隔时间。
+     * 单位由 unit() 定义。
+     */
+    long fixedDelay() default -1L;
+
+    /**
+     * 首次执行前的初始延迟。
+     * 单位由 unit() 定义。
+     */
+    long initialDelay() default 0L;
+
+    /**
+     * 时间单位，默认为秒。
+     */
+    TimeUnit unit() default TimeUnit.SECONDS;
+
+    /**
+     * 是否在应用启动时预热缓存
+     *
+     * @return
+     */
+    boolean preheatOnStartup() default false;
+
+
+    boolean distributedLock() default true;
+
+    /**
+     * 抖动时间，单位为毫秒。
+     * @return
+     */
+    long jitterMillis() default 0;
+
+    /**
+     * 分布式锁等待时间，单位为秒。
+     * @return
+     */
+    long lockWaitSeconds() default 0;
+
+    /**
+     * 分布式锁租约时间，单位为秒。
+     * @return
+     */
+    long lockLeaseSeconds() default 30;
+
+}

--- a/fluxcache-core/src/main/java/com/fluxcache/core/annotation/FluxSpringCacheAnnotationParser.java
+++ b/fluxcache-core/src/main/java/com/fluxcache/core/annotation/FluxSpringCacheAnnotationParser.java
@@ -1,12 +1,17 @@
 package com.fluxcache.core.annotation;
 
 import com.fluxcache.core.enums.FluxCacheLevel;
-import com.fluxcache.core.model.FluxCacheCacheableConfig;
+import com.fluxcache.core.model.FluxCacheConfig;
 import com.fluxcache.core.model.FluxCacheEvictOperation;
 import com.fluxcache.core.model.FluxCacheOperation;
 import com.fluxcache.core.model.FluxCachePutOperation;
 import com.fluxcache.core.model.FluxMultilevelCacheCacheable;
 import com.fluxcache.core.properties.FluxCacheProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.lang.Nullable;
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
@@ -14,10 +19,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Set;
-import lombok.RequiredArgsConstructor;
-import org.springframework.core.annotation.AnnotatedElementUtils;
-import org.springframework.core.annotation.AnnotationUtils;
-import org.springframework.lang.Nullable;
 
 /**
  * @author : wh
@@ -56,21 +57,21 @@ public class FluxSpringCacheAnnotationParser implements FluxCacheAnnotationParse
     @Nullable
     private FluxCacheOperation parseCacheAnnotation(AnnotatedElement ae, boolean localOnly) {
         Collection<? extends Annotation> anns = (localOnly ?
-            AnnotatedElementUtils.getAllMergedAnnotations(ae, CACHE_OPERATION_ANNOTATIONS) :
-            AnnotatedElementUtils.findAllMergedAnnotations(ae, CACHE_OPERATION_ANNOTATIONS));
+                AnnotatedElementUtils.getAllMergedAnnotations(ae, CACHE_OPERATION_ANNOTATIONS) :
+                AnnotatedElementUtils.findAllMergedAnnotations(ae, CACHE_OPERATION_ANNOTATIONS));
         if (anns.isEmpty()) {
             return null;
         }
 
         final Collection<FluxCacheOperation> ops = new ArrayList<>(1);
         anns.stream().filter(ann -> ann instanceof FluxCacheEvict).forEach(
-            ann -> ops.add(parseEvictAnnotation(ae, (FluxCacheEvict) ann)));
+                ann -> ops.add(parseEvictAnnotation(ae, (FluxCacheEvict) ann)));
 
         anns.stream().filter(ann -> ann instanceof FluxCachePut).forEach(
-            ann -> ops.add(parsePutAnnotation(ae, (FluxCachePut) ann)));
+                ann -> ops.add(parsePutAnnotation(ae, (FluxCachePut) ann)));
 
         anns.stream().filter(ann -> ann instanceof FluxCacheable).forEach(
-            ann -> ops.add(parseFluxCacheableAnnotation(ae, (FluxCacheable) ann)));
+                ann -> ops.add(parseFluxCacheableAnnotation(ae, (FluxCacheable) ann)));
 
         if (ops.size() > 1) {
             throw new RuntimeException("flux cache Only single operations are supported");
@@ -87,10 +88,10 @@ public class FluxSpringCacheAnnotationParser implements FluxCacheAnnotationParse
      */
     private FluxCacheOperation parsePutAnnotation(AnnotatedElement ae, FluxCachePut cp) {
         return new FluxCachePutOperation.Builder()
-            .setMethodName(ae.toString())
-            .setCacheName(cp.cacheName())
-            .setKey(cp.key())
-            .build();
+                .setMethodName(ae.toString())
+                .setCacheName(cp.cacheName())
+                .setKey(cp.key())
+                .build();
     }
 
     /**
@@ -101,18 +102,18 @@ public class FluxSpringCacheAnnotationParser implements FluxCacheAnnotationParse
      * @return
      */
     private FluxCacheOperation parseFluxCacheableAnnotation(AnnotatedElement ae, FluxCacheable ca) {
-        FluxCacheCacheableConfig firstCacheConfig = new FluxCacheCacheableConfig(ca.firstCacheable());
+        FluxCacheConfig firstCacheConfig = new FluxCacheConfig(ca.firstCacheable());
         FluxCacheLevel cacheLevel = cacheProperties.fluxCacheLevel(ca.fluxCacheLevel());
-        FluxCacheCacheableConfig secondaryCacheable = FluxCacheLevel.isSecondaryCacheable(cacheLevel) ? new FluxCacheCacheableConfig(ca.secondaryCacheable()) : null;
+        FluxCacheConfig secondaryCacheable = FluxCacheLevel.isSecondaryCacheable(cacheLevel) ? new FluxCacheConfig(ca.secondaryCacheable()) : null;
         FluxCacheOperation fluxCacheOperation = new FluxMultilevelCacheCacheable.Builder()
-            .setFirstCacheConfig(firstCacheConfig)
-            .setSecondaryCacheable(secondaryCacheable)
-            .setAllowCacheNull(ca.allowCacheNull())
-            .setFluxCacheLevel(cacheLevel)
-            .setCacheName(ca.cacheName())
-            .setMethodName(ae.toString())
-            .setKey(ca.key())
-            .build();
+                .setFirstCacheConfig(firstCacheConfig)
+                .setSecondaryCacheable(secondaryCacheable)
+                .setAllowNullValues(ca.allowCacheNull())
+                .setFluxCacheLevel(cacheLevel)
+                .setCacheName(ca.cacheName())
+                .setMethodName(ae.toString())
+                .setKey(ca.key())
+                .build();
         return fluxCacheOperation;
     }
 
@@ -125,9 +126,9 @@ public class FluxSpringCacheAnnotationParser implements FluxCacheAnnotationParse
      */
     private FluxCacheOperation parseEvictAnnotation(AnnotatedElement ae, FluxCacheEvict ce) {
         return new FluxCacheEvictOperation.Builder().setMethodName(ae.toString())
-            .setCacheName(ce.cacheName())
-            .setKey(ce.key())
-            .build();
+                .setCacheName(ce.cacheName())
+                .setKey(ce.key())
+                .build();
     }
 
 }

--- a/fluxcache-core/src/main/java/com/fluxcache/core/caffeine/RedissonLocalCacheEvictListener.java
+++ b/fluxcache-core/src/main/java/com/fluxcache/core/caffeine/RedissonLocalCacheEvictListener.java
@@ -6,7 +6,6 @@ import com.fluxcache.core.impl.FluxAbstractValueAdaptingCache;
 import com.fluxcache.core.impl.FluxRedissonCaffeineCache;
 import com.fluxcache.core.model.DeleteCacheDTO;
 import com.fluxcache.core.properties.FluxCacheProperties;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RTopic;
@@ -15,6 +14,8 @@ import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.core.Ordered;
 import org.springframework.util.ObjectUtils;
+
+import java.util.Objects;
 
 /**
  * @author : wh

--- a/fluxcache-core/src/main/java/com/fluxcache/core/config/FluxProxyCacheAutoConfiguration.java
+++ b/fluxcache-core/src/main/java/com/fluxcache/core/config/FluxProxyCacheAutoConfiguration.java
@@ -136,6 +136,7 @@ public class FluxProxyCacheAutoConfiguration {
 
 
     @Bean
+    @ConditionalOnClass(RedissonClient.class)
     public FluxRefreshTaskRegistrar cacheRefreshTaskRegistrar(ApplicationContext context, TaskScheduler taskScheduler,
                                                               FluxCacheManager cacheManager, RedissonClient redissonClient) {
         return new FluxRefreshTaskRegistrar(context, taskScheduler, cacheManager, redissonClient, new FluxCacheRefreshExecutor());

--- a/fluxcache-core/src/main/java/com/fluxcache/core/impl/FluxAbstractValueAdaptingCache.java
+++ b/fluxcache-core/src/main/java/com/fluxcache/core/impl/FluxAbstractValueAdaptingCache.java
@@ -4,15 +4,14 @@ import com.fluxcache.core.FluxCache;
 import com.fluxcache.core.FluxSimpleValueWrapper;
 import com.fluxcache.core.model.FluxNullValue;
 import com.fluxcache.core.monitor.FluxCacheMonitor;
-import com.fluxcache.core.monitor.FluxCacheMonitorEvent;
-import com.fluxcache.core.monitor.MonitorEventEnum;
 import com.fluxcache.core.properties.FluxCacheProperties;
+import org.springframework.lang.Nullable;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.Callable;
-import org.springframework.lang.Nullable;
 
 /**
  * @author : wh
@@ -35,115 +34,91 @@ public abstract class FluxAbstractValueAdaptingCache<K, V> implements FluxCache<
     /**
      * Create an {@code AbstractValueAdaptingCache} with the given setting.
      *
-     * @param allowCacheNull 
+     * @param allowCacheNull whether to allow for {@code null} values
      */
     protected FluxAbstractValueAdaptingCache(boolean allowCacheNull, FluxCacheMonitor cacheMonitor, String name,
-        FluxCacheProperties cacheProperties) {
+                                              FluxCacheProperties cacheProperties) {
         this.allowCacheNull = allowCacheNull;
         this.cacheMonitor = cacheMonitor;
         this.name = name;
         this.cacheProperties = cacheProperties;
     }
-    
 
     @Override
     @Nullable
     public ValueWrapper<V> get(K key) {
-        long startTime = System.currentTimeMillis();
-        ValueWrapper<V> wrapper = toValueWrapper(lookup(key));
-        publishCacheMonitorEvent(Objects.nonNull(wrapper) ? MonitorEventEnum.CACHE_HIT : MonitorEventEnum.CACHE_MISSING, 1L, startTime);
-        return wrapper;
+        V storeVal = lookup(key);
+        return toValueWrapper(storeVal);
     }
 
     @Override
     @Nullable
     public V get(K key, @Nullable Class<V> type) {
-        long startTime = System.currentTimeMillis();
         V value = fromStoreValue(lookup(key));
         if (value != null && type != null && !type.isInstance(value)) {
-            throw new IllegalStateException(
-                "Cached value is not of required type [" + type.getName() + "]: " + value);
+            throw new IllegalStateException("Cached value is not of required type [" + type.getName() + "]: " + value);
         }
-        publishCacheMonitorEvent(Objects.nonNull(value) ? MonitorEventEnum.CACHE_HIT : MonitorEventEnum.CACHE_MISSING, 1L, startTime);
         return value;
     }
 
     @Override
     public V get(K key, Callable<V> valueLoader) {
-        long startTime = System.currentTimeMillis();
-        V value = getValue(key, valueLoader);
-        publishCacheMonitorEvent(value == null || !value.getClass().isAssignableFrom(valueLoader.getClass()) ?
-            MonitorEventEnum.CACHE_MISSING : MonitorEventEnum.CACHE_HIT, 1L, startTime);
-        return value;
+        return getValue(key, valueLoader);
     }
 
     @Override
     public void put(K key, @Nullable Object value) {
-        if (Objects.isNull(value) && !allowCacheNull) {
+        if (value == null && !allowCacheNull) {
             return;
         }
-        long startTime = System.currentTimeMillis();
         putValue(key, toStoreValue(value));
-        publishCacheMonitorEvent(MonitorEventEnum.CACHE_PUT, 1L, startTime);
     }
 
     @Override
     public Map<K, V> getAll(List<K> keys, Class<V> type) {
-        long startTime = System.currentTimeMillis();
         if (Objects.isNull(keys)) {
             throw new IllegalArgumentException(
-                "Cache '" + getName() + "' getAll is configured to not allow null list");
+                    "Cache '" + getName() + "' getAll is configured to not allow null list");
         }
         Map<K, V> map = getValues(keys);
-        return getMap(startTime, map, keys.size());
-    }
-
-    private Map<K, V> getMap(long startTime, Map<K, V> map, int size) {
         if (map == null || map.isEmpty()) {
             return Map.of();
         }
         Map<K, V> values = new HashMap<>(map);
-        values.replaceAll((key, value) -> fromStoreValue(value));
-        publishCacheMonitorEvent(MonitorEventEnum.CACHE_HIT, values.size(), startTime);
-        publishCacheMonitorEvent(MonitorEventEnum.CACHE_MISSING, size - values.size(), startTime);
+        values.replaceAll((k, v) -> fromStoreValue(v));
         return values;
+
     }
 
     public abstract Map<K, V> getValues(List<K> keys);
 
     @Override
     public Map<K, V> getAllAsync(List<K> keys, Class<V> type) {
-        long startTime = System.currentTimeMillis();
         if (Objects.isNull(keys)) {
             throw new IllegalArgumentException(
-                "Cache '" + getName() + "' getAll is configured to not allow null list");
+                    "Cache '" + getName() + "' getAll is configured to not allow null list");
         }
-        Map<K, V> map = getValuesAsync(keys);
-        return getMap(startTime, map, keys.size());
+        return getValuesAsync(keys);
     }
 
     public abstract Map<K, V> getValuesAsync(List<K> keys);
 
     @Override
     public void putAll(@Nullable Map<K, V> map) {
-        long startTime = System.currentTimeMillis();
         if (Objects.isNull(map)) {
             throw new IllegalArgumentException(
-                "Cache '" + getName() + "' putAll is configured to not allow null map");
+                    "Cache '" + getName() + "' putAll is configured to not allow null map");
         }
         putValues(map);
-        publishCacheMonitorEvent(MonitorEventEnum.CACHE_PUT, map.size(), startTime);
     }
 
     @Override
     public void putAllAsync(@Nullable Map<K, V> map) {
-        long startTime = System.currentTimeMillis();
         if (Objects.isNull(map)) {
             throw new IllegalArgumentException(
-                "Cache '" + getName() + "' putAll is configured to not allow null map");
+                    "Cache '" + getName() + "' putAll is configured to not allow null map");
         }
         putValuesAsync(map);
-        publishCacheMonitorEvent(MonitorEventEnum.CACHE_PUT, map.size(), startTime);
     }
 
     protected abstract void putValues(@Nullable Map<K, V> map);
@@ -152,16 +127,12 @@ public abstract class FluxAbstractValueAdaptingCache<K, V> implements FluxCache<
 
     @Override
     public void evict(K key) {
-        long startTime = System.currentTimeMillis();
         evictValue(key);
-        publishCacheMonitorEvent(MonitorEventEnum.CACHE_EVICT, 1L, startTime);
     }
 
     @Override
     public void bathEvict(List<K> keys) {
-        long startTime = System.currentTimeMillis();
         bathEvictValue(keys);
-        publishCacheMonitorEvent(MonitorEventEnum.CACHE_EVICT, keys.size(), startTime);
     }
 
     @Nullable
@@ -213,13 +184,9 @@ public abstract class FluxAbstractValueAdaptingCache<K, V> implements FluxCache<
                 return FluxNullValue.INSTANCE;
             }
             throw new IllegalArgumentException(
-                "Cache '" + getName() + "' is configured to not allow null values but null was provided");
+                    "Cache '" + getName() + "' is configured to not allow null values but null was provided");
         }
         return userValue;
-    }
-
-    public boolean allowCacheNull() {
-        return this.allowCacheNull;
     }
 
     /**
@@ -235,15 +202,9 @@ public abstract class FluxAbstractValueAdaptingCache<K, V> implements FluxCache<
         return (storeValue != null ? new FluxSimpleValueWrapper<>(fromStoreValue(storeValue)) : null);
     }
 
-    private void publishCacheMonitorEvent(MonitorEventEnum eventEnum, long count, long startTime) {
-        if (cacheProperties.isCacheMonitorEnable()) {
-            FluxCacheMonitorEvent event = new FluxCacheMonitorEvent();
-            event.setCacheName(this.name);
-            event.setMonitorEventEnum(eventEnum);
-            event.setLoadTime(System.currentTimeMillis() - startTime);
-            event.setCount(count);
-            cacheMonitor.publishMonitorEvent(event);
-        }
+    public boolean allowCacheNull() {
+        return this.allowCacheNull;
     }
+
 
 }

--- a/fluxcache-core/src/main/java/com/fluxcache/core/impl/FluxCacheFactory.java
+++ b/fluxcache-core/src/main/java/com/fluxcache/core/impl/FluxCacheFactory.java
@@ -6,15 +6,16 @@ import com.fluxcache.core.caffeine.sync.CacheSyncStrategy;
 import com.fluxcache.core.enums.FluxCacheLevel;
 import com.fluxcache.core.enums.FluxCacheType;
 import com.fluxcache.core.model.FluxCacheCacheable;
-import com.fluxcache.core.model.FluxCacheCacheableConfig;
+import com.fluxcache.core.model.FluxCacheConfig;
 import com.fluxcache.core.model.FluxMultilevelCacheCacheable;
 import com.fluxcache.core.monitor.FluxCacheMonitor;
 import com.fluxcache.core.properties.FluxCacheProperties;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import org.redisson.api.RedissonClient;
+
 import java.util.Arrays;
 import java.util.Objects;
-import org.redisson.api.RedissonClient;
 
 /**
  * @author : wh
@@ -23,64 +24,62 @@ import org.redisson.api.RedissonClient;
  */
 public class FluxCacheFactory {
 
-
     public static FluxCache<?, ?> createFluxCache(FluxMultilevelCacheCacheable ca, RedissonClient redissonClient,
-        FluxCacheProperties cacheProperties, CacheSyncStrategy cacheSyncStrategy, FluxCacheMonitor cacheMonitor) {
+                                                  FluxCacheProperties cacheProperties, CacheSyncStrategy cacheSyncStrategy, FluxCacheMonitor cacheMonitor) {
         FluxCacheLevel cacheLevel = Objects.equals(ca.getFluxCacheLevel(), FluxCacheLevel.NULL) ? cacheProperties.getDefaultCacheLevel() : ca.getFluxCacheLevel();
         // 一级缓存
         if (Objects.equals(cacheLevel, FluxCacheLevel.FirstCacheable)) {
-            FluxCacheCacheableConfig config = ca.getFirstCacheConfig();
+            FluxCacheConfig config = ca.getFirstCacheConfig();
             return CacheTypeStrategy.getStrategy(config.getCacheType()).createFluxCache((FluxCacheCacheable) ca.convertsFluxCacheCacheable(config), redissonClient, cacheSyncStrategy, cacheProperties, cacheMonitor);
         }
         // 二级缓存
         if (FluxCacheLevel.isSecondaryCacheable(cacheLevel)) {
-            FluxCacheCacheableConfig config = ca.getFirstCacheConfig();
+            FluxCacheConfig firstCfg = ca.getFirstCacheConfig();
 
-            FluxCacheCacheableConfig secondaryCacheConfig = ca.getSecondaryCacheConfig();
+            FluxCacheConfig secondCfg = ca.getSecondaryCacheConfig();
 
-            FluxCacheCacheable cacheCacheable = (FluxCacheCacheable) ca.convertsFluxCacheCacheable(secondaryCacheConfig);
+            FluxCacheCacheable cacheCacheable = (FluxCacheCacheable) ca.convertsFluxCacheCacheable(secondCfg);
 
-            FluxAbstractValueAdaptingCache<?, ?> FluxFirstCache = CacheTypeStrategy.getStrategy(secondaryCacheConfig.getCacheType()).createFluxCache(cacheCacheable, redissonClient, cacheSyncStrategy, cacheProperties, cacheMonitor);
-            FluxAbstractValueAdaptingCache<?, ?> FluxSecondaryCache = CacheTypeStrategy.getStrategy(config.getCacheType()).createFluxCache(cacheCacheable, redissonClient, cacheSyncStrategy, cacheProperties, cacheMonitor);
+            FluxAbstractValueAdaptingCache<?, ?> fluxFirstCache = CacheTypeStrategy.getStrategy(secondCfg.getCacheType()).createFluxCache(cacheCacheable, redissonClient, cacheSyncStrategy, cacheProperties, cacheMonitor);
+            FluxAbstractValueAdaptingCache<?, ?> fluxSecondaryCache = CacheTypeStrategy.getStrategy(firstCfg.getCacheType()).createFluxCache(cacheCacheable, redissonClient, cacheSyncStrategy, cacheProperties, cacheMonitor);
 
-            FluxRedissonCaffeineCache<?, ?> cache = new FluxRedissonCaffeineCache(ca.isAllowCacheNull(), ca.getCacheName(), FluxFirstCache, FluxSecondaryCache, cacheMonitor, cacheProperties);
+            FluxRedissonCaffeineCache<?, ?> cache = new FluxRedissonCaffeineCache(ca.isAllowCacheNull(), ca.getCacheName(), fluxFirstCache, fluxSecondaryCache, cacheMonitor, cacheProperties);
             return cache;
         }
         return null;
     }
-
 
     private enum CacheTypeStrategy {
 
         CAFFEINE(FluxCacheType.CAFFEINE) {
             @Override
             protected FluxAbstractValueAdaptingCache<?, ?> createFluxCache(FluxCacheCacheable ca,
-                RedissonClient redissonClient,
-                CacheSyncStrategy cacheSyncStrategy, FluxCacheProperties cacheProperties,
-                FluxCacheMonitor cacheMonitor) {
+                                                                           RedissonClient redissonClient,
+                                                                           CacheSyncStrategy cacheSyncStrategy, FluxCacheProperties cacheProperties,
+                                                                           FluxCacheMonitor cacheMonitor) {
                 Cache<Object, Object> caffeineCache = Caffeine.newBuilder()
-                    .expireAfterWrite(ca.getTtl(), ca.getUnit())
-                    .initialCapacity(ca.getInitSize())
-                    .maximumSize(ca.getMaxSize())
-                    .build();
-                return new FluxCaffeineCache<>(ca.getCacheName(), caffeineCache, ca.isAllowCacheNull(),  cacheSyncStrategy, cacheProperties, cacheMonitor);
+                        .expireAfterWrite(ca.getTtl(), ca.getUnit())
+                        .initialCapacity(ca.getInitSize())
+                        .maximumSize(ca.getMaxSize())
+                        .build();
+                return new FluxCaffeineCache<>(ca.getCacheName(), caffeineCache, ca.isAllowCacheNull(), cacheSyncStrategy, cacheProperties, cacheMonitor);
             }
         },
         REDIS(FluxCacheType.REDIS_R_MAP) {
             @Override
             protected FluxAbstractValueAdaptingCache<?, ?> createFluxCache(FluxCacheCacheable ca,
-                RedissonClient redissonClient,
-                CacheSyncStrategy cacheSyncStrategy, FluxCacheProperties cacheProperties,
-                FluxCacheMonitor cacheMonitor) {
+                                                                           RedissonClient redissonClient,
+                                                                           CacheSyncStrategy cacheSyncStrategy, FluxCacheProperties cacheProperties,
+                                                                           FluxCacheMonitor cacheMonitor) {
                 return new FluxRedissonCacheByRMapCache<>(ca.isAllowCacheNull(), redissonClient, ca, cacheMonitor, cacheProperties);
             }
         },
         REDIS_BUCKET(FluxCacheType.REDIS_BUCKET) {
             @Override
             protected FluxAbstractValueAdaptingCache<?, ?> createFluxCache(FluxCacheCacheable ca,
-                RedissonClient redissonClient,
-                CacheSyncStrategy cacheSyncStrategy, FluxCacheProperties cacheProperties,
-                FluxCacheMonitor cacheMonitor) {
+                                                                           RedissonClient redissonClient,
+                                                                           CacheSyncStrategy cacheSyncStrategy, FluxCacheProperties cacheProperties,
+                                                                           FluxCacheMonitor cacheMonitor) {
                 return new FluxRedissonCacheByBucket<>(ca.isAllowCacheNull(), redissonClient, ca, cacheMonitor, cacheProperties);
             }
         };
@@ -92,14 +91,14 @@ public class FluxCacheFactory {
         }
 
         protected abstract FluxAbstractValueAdaptingCache<?, ?> createFluxCache(FluxCacheCacheable ca,
-            RedissonClient redissonClient,
-            CacheSyncStrategy cacheSyncStrategy, FluxCacheProperties cacheProperties, FluxCacheMonitor cacheMonitor);
+                                                                                RedissonClient redissonClient,
+                                                                                CacheSyncStrategy cacheSyncStrategy, FluxCacheProperties cacheProperties, FluxCacheMonitor cacheMonitor);
 
         public static CacheTypeStrategy getStrategy(FluxCacheType cacheType) {
             return Arrays.stream(values())
-                .filter(strategy -> strategy.cacheType == cacheType)
-                .findFirst()
-                .orElse(null);
+                    .filter(strategy -> strategy.cacheType == cacheType)
+                    .findFirst()
+                    .orElse(null);
 
         }
 

--- a/fluxcache-core/src/main/java/com/fluxcache/core/interceptor/FluxCacheAnnotationAdvisor.java
+++ b/fluxcache-core/src/main/java/com/fluxcache/core/interceptor/FluxCacheAnnotationAdvisor.java
@@ -1,8 +1,5 @@
 package com.fluxcache.core.interceptor;
 
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
 import lombok.NonNull;
 import org.aopalliance.aop.Advice;
 import org.aopalliance.intercept.MethodInterceptor;
@@ -20,6 +17,10 @@ import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.util.Assert;
 
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
 /**
  * @author : wh
  * @date : 2024/11/12 12:42
@@ -34,7 +35,7 @@ public class FluxCacheAnnotationAdvisor extends AbstractPointcutAdvisor implemen
     private final Class<? extends Annotation> annotation;
 
     public FluxCacheAnnotationAdvisor(@NonNull MethodInterceptor advice,
-        @NonNull Class<? extends Annotation> annotation) {
+                                       @NonNull Class<? extends Annotation> annotation) {
         this.advice = advice;
         this.annotation = annotation;
         this.pointcut = buildPointcut();

--- a/fluxcache-core/src/main/java/com/fluxcache/core/model/FluxCacheConfig.java
+++ b/fluxcache-core/src/main/java/com/fluxcache/core/model/FluxCacheConfig.java
@@ -1,0 +1,95 @@
+package com.fluxcache.core.model;
+
+import com.fluxcache.core.annotation.FirstCacheable;
+import com.fluxcache.core.annotation.SecondaryCacheable;
+import com.fluxcache.core.enums.FluxCacheType;
+import lombok.Data;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author : wh
+ * @date : 2025/9/16 14:18
+ * @description:
+ */
+@Data
+public class FluxCacheConfig {
+
+    private final Long ttl;
+
+    private final int initSize;
+
+    private final TimeUnit unit;
+
+    private int maxSize;
+
+    private FluxCacheType cacheType;
+
+    public FluxCacheConfig(FirstCacheable cacheable) {
+        this.ttl = cacheable.ttl();
+        this.initSize = cacheable.initSize();
+        this.unit = cacheable.unit();
+        this.maxSize = cacheable.maxSize();
+        this.cacheType = cacheable.fluxCacheType();
+    }
+
+    public FluxCacheConfig(SecondaryCacheable cacheable) {
+        this.ttl = cacheable.ttl();
+        this.initSize = cacheable.initSize();
+        this.unit = cacheable.unit();
+        this.maxSize = cacheable.maxSize();
+        this.cacheType = cacheable.fluxCacheType();
+    }
+
+    public FluxCacheConfig(Builder builder) {
+        this.ttl = builder.ttl;
+        this.initSize = builder.initSize;
+        this.unit = builder.unit;
+        this.maxSize = builder.maxSize;
+        this.cacheType = builder.cacheType;
+    }
+
+    public static class Builder {
+
+        private Long ttl;
+
+        private int initSize;
+
+        private TimeUnit unit;
+
+        private int maxSize;
+
+        private FluxCacheType cacheType;
+
+        public Builder setTtl(Long ttl) {
+            this.ttl = ttl;
+            return this;
+        }
+
+        public Builder setInitSize(int initSize) {
+            this.initSize = initSize;
+            return this;
+        }
+
+        public Builder setUnit(TimeUnit unit) {
+            this.unit = unit;
+            return this;
+        }
+
+        public Builder setMaxSize(int maxSize) {
+            this.maxSize = maxSize;
+            return this;
+        }
+
+        public Builder setCacheType(FluxCacheType cacheType) {
+            this.cacheType = cacheType;
+            return this;
+        }
+
+        public FluxCacheConfig build() {
+            return new FluxCacheConfig(this);
+
+        }
+    }
+
+}

--- a/fluxcache-core/src/main/java/com/fluxcache/core/model/FluxMultilevelCacheCacheable.java
+++ b/fluxcache-core/src/main/java/com/fluxcache/core/model/FluxMultilevelCacheCacheable.java
@@ -11,9 +11,9 @@ import lombok.Getter;
 @Getter
 public class FluxMultilevelCacheCacheable extends FluxCacheOperation {
 
-    private final FluxCacheCacheableConfig firstCacheConfig;
+    private final FluxCacheConfig firstCacheConfig;
 
-    private final FluxCacheCacheableConfig secondaryCacheConfig;
+    private final FluxCacheConfig secondaryCacheConfig;
 
     private final boolean allowCacheNull;
 
@@ -25,46 +25,47 @@ public class FluxMultilevelCacheCacheable extends FluxCacheOperation {
     }
 
     public FluxMultilevelCacheCacheable(CacheConfigBuilder builder) {
-        super(builder.cacheName, builder.fluxCacheLevel);
+        super(builder.cacheName, builder.FluxCacheLevel);
         this.firstCacheConfig = builder.firstCacheConfig;
         this.secondaryCacheConfig = builder.secondaryCacheConfig;
         this.allowCacheNull = builder.allowNullValues;
     }
 
-    public FluxCacheOperation convertsFluxCacheCacheable(FluxCacheCacheableConfig cacheableConfig) {
+    public FluxCacheOperation convertsFluxCacheCacheable(FluxCacheConfig cacheableConfig) {
 
         return new FluxCacheCacheable.Builder()
-            .setUnit(cacheableConfig.getUnit())
-            .setTtl(cacheableConfig.getTtl())
-            .setInitSize(cacheableConfig.getInitSize())
-            .setMaxSize(cacheableConfig.getMaxSize())
-            .setAllowCacheNull(this.allowCacheNull)
-            .setCacheName(this.getCacheName())
-            .setKey(this.getKey())
-            .setMethodName(this.getMethodName())
-            .build();
+                .setUnit(cacheableConfig.getUnit())
+                .setTtl(cacheableConfig.getTtl())
+                .setInitSize(cacheableConfig.getInitSize())
+                .setMaxSize(cacheableConfig.getMaxSize())
+                .setAllowCacheNull(this.isAllowCacheNull())
+                .setCacheName(this.getCacheName())
+                .setKey(this.getKey())
+                .setMethodName(this.getMethodName())
+                .build();
     }
+
 
     public static class Builder extends FluxCacheOperation.Builder {
 
-        private FluxCacheCacheableConfig firstCacheConfig;
+        private FluxCacheConfig firstCacheConfig;
 
-        private FluxCacheCacheableConfig secondaryCacheConfig;
+        private FluxCacheConfig secondaryCacheConfig;
 
         private boolean allowNullValues;
 
-        public Builder setFirstCacheConfig(FluxCacheCacheableConfig firstCacheConfig) {
+        public Builder setFirstCacheConfig(FluxCacheConfig firstCacheConfig) {
             this.firstCacheConfig = firstCacheConfig;
             return this;
         }
 
-        public Builder setSecondaryCacheable(FluxCacheCacheableConfig secondaryCacheConfig) {
+        public Builder setSecondaryCacheable(FluxCacheConfig secondaryCacheConfig) {
             this.secondaryCacheConfig = secondaryCacheConfig;
             return this;
         }
 
-        public Builder setAllowCacheNull(boolean allowCacheNull) {
-            this.allowNullValues = allowCacheNull;
+        public Builder setAllowNullValues(boolean allowNullValues) {
+            this.allowNullValues = allowNullValues;
             return this;
         }
 
@@ -74,6 +75,9 @@ public class FluxMultilevelCacheCacheable extends FluxCacheOperation {
         }
     }
 
+    /**
+     * 手动注册 todo Builder and CacheConfigBuilder is reduce
+     */
     public static class CacheConfigBuilder {
 
         /**
@@ -81,11 +85,11 @@ public class FluxMultilevelCacheCacheable extends FluxCacheOperation {
          */
         private String cacheName;
 
-        private FluxCacheLevel fluxCacheLevel;
+        private FluxCacheLevel FluxCacheLevel;
 
-        private FluxCacheCacheableConfig firstCacheConfig;
+        private FluxCacheConfig firstCacheConfig;
 
-        private FluxCacheCacheableConfig secondaryCacheConfig;
+        private FluxCacheConfig secondaryCacheConfig;
 
         private boolean allowNullValues;
 
@@ -94,17 +98,17 @@ public class FluxMultilevelCacheCacheable extends FluxCacheOperation {
             return this;
         }
 
-        public CacheConfigBuilder setFluxCacheLevel(FluxCacheLevel fluxCacheLevel) {
-            this.fluxCacheLevel = fluxCacheLevel;
+        public CacheConfigBuilder setFluxCacheLevel(FluxCacheLevel FluxCacheLevel) {
+            this.FluxCacheLevel = FluxCacheLevel;
             return this;
         }
 
-        public CacheConfigBuilder setFirstCacheConfig(FluxCacheCacheableConfig firstCacheConfig) {
+        public CacheConfigBuilder setFirstCacheConfig(FluxCacheConfig firstCacheConfig) {
             this.firstCacheConfig = firstCacheConfig;
             return this;
         }
 
-        public CacheConfigBuilder setSecondaryCacheConfig(FluxCacheCacheableConfig secondaryCacheConfig) {
+        public CacheConfigBuilder setSecondaryCacheConfig(FluxCacheConfig secondaryCacheConfig) {
             this.secondaryCacheConfig = secondaryCacheConfig;
             return this;
         }

--- a/fluxcache-core/src/main/java/com/fluxcache/core/monitor/FluxCacheInfo.java
+++ b/fluxcache-core/src/main/java/com/fluxcache/core/monitor/FluxCacheInfo.java
@@ -1,8 +1,9 @@
 package com.fluxcache.core.monitor;
 
+import lombok.Data;
+
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;
-import lombok.Data;
 
 /**
  * @author : wh
@@ -15,49 +16,47 @@ public class FluxCacheInfo {
     /**
      * 命中次数
      */
-    private LongAdder hit;
+    private final LongAdder hit = new LongAdder();
 
     /**
-     * 失败次数
+     * 未命中次数
      */
-    private LongAdder fail;
+    private final LongAdder fail = new LongAdder();
 
     /**
      * 删除次数
      */
-    private LongAdder evictCount;
+    private final LongAdder evictCount = new LongAdder();
 
     /**
      * 更新次数
      */
-    private LongAdder putCount;
+    private final LongAdder putCount = new LongAdder();
 
     /**
-     * 请求次数
+     * 请求次数（命中 + 未命中）
      */
-    private LongAdder requestCount;
+    private final LongAdder requestCount = new LongAdder();
 
     /**
-     * 最大加载时间
+     * 当前窗口内的最大加载耗时（毫秒）
      */
-    private AtomicLong maxLoadTime;
+    private final AtomicLong maxLoadTime = new AtomicLong(0L);
 
     /**
-     * 开始时间
+     * 窗口开始时间（毫秒时间戳）
      */
-    private AtomicLong startTime;
+    private final AtomicLong startTime = new AtomicLong(0L);
 
     /**
-     * 结束时间
+     * 窗口结束时间（毫秒时间戳）
      */
-    private AtomicLong endTime;
+    private final AtomicLong endTime = new AtomicLong(0L);
 
-    public FluxCacheInfo() {
-        this.hit = new LongAdder();
-        this.fail = new LongAdder();
-        this.evictCount = new LongAdder();
-        this.putCount = new LongAdder();
-        this.requestCount = new LongAdder();
-        this.maxLoadTime = new AtomicLong(Long.MIN_VALUE);
+    public static FluxCacheInfo startAt(long startMillis, long windowMillis) {
+        FluxCacheInfo info = new FluxCacheInfo();
+        info.getStartTime().set(startMillis);
+        info.getEndTime().set(startMillis + windowMillis);
+        return info;
     }
 }

--- a/fluxcache-core/src/main/java/com/fluxcache/core/monitor/FluxCacheMonitorEvent.java
+++ b/fluxcache-core/src/main/java/com/fluxcache/core/monitor/FluxCacheMonitorEvent.java
@@ -1,6 +1,9 @@
 package com.fluxcache.core.monitor;
 
+import lombok.Builder;
 import lombok.Data;
+
+import java.util.Objects;
 
 /**
  * @author : wh
@@ -8,13 +11,40 @@ import lombok.Data;
  * @description:
  */
 @Data
+@Builder
 public class FluxCacheMonitorEvent {
 
     private String cacheName;
 
     private MonitorEventEnum monitorEventEnum;
 
+    /**
+     * 仅对需要真实加载的场景赋值（PUT 场景），单位毫秒 毫秒
+     */
     private Long loadTime;
 
+    /**
+     * 事件次数，一般为 1，允许批量上报
+     */
     private Long count;
+
+    /**
+     * 事件发生时间（ms）
+     */
+    private Long timestamp;
+
+
+    private String key;
+
+    private boolean forceRefresh;
+
+    public Long count() {
+        return Objects.isNull(count) ? 1L : count;
+    }
+
+    public Long loadTime() {
+        return Objects.isNull(loadTime) ? 0L : loadTime;
+    }
+
+
 }

--- a/fluxcache-core/src/main/java/com/fluxcache/core/preheat/FluxCacheRefreshContext.java
+++ b/fluxcache-core/src/main/java/com/fluxcache/core/preheat/FluxCacheRefreshContext.java
@@ -1,0 +1,31 @@
+package com.fluxcache.core.preheat;
+
+import com.fluxcache.core.FluxCache;
+import com.fluxcache.core.annotation.FluxRefresh;
+import lombok.Builder;
+import lombok.Data;
+
+import java.lang.reflect.Method;
+import java.util.Collection;
+
+/**
+ * @author : wh
+ * @date : 2025/8/12
+ * @description:
+ */
+@Data
+@Builder
+public class FluxCacheRefreshContext {
+
+    private Object bean;
+
+    private Method method;
+
+    private String cacheName;
+
+    private FluxRefresh refreshConfig;
+
+    private FluxCache cache;
+
+    private Collection<?> keys;
+}

--- a/fluxcache-core/src/main/java/com/fluxcache/core/preheat/FluxCacheRefreshExecutor.java
+++ b/fluxcache-core/src/main/java/com/fluxcache/core/preheat/FluxCacheRefreshExecutor.java
@@ -1,0 +1,71 @@
+package com.fluxcache.core.preheat;
+
+import com.fluxcache.core.FluxCache;
+import com.fluxcache.core.annotation.FluxRefresh;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.ReflectionUtils;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+/**
+ * @author : wh
+ * @date : 2025/8/12
+ * @description:
+ */
+@Slf4j
+public class FluxCacheRefreshExecutor {
+
+//    private final ConcurrentHashMap<Object, Long> keyLastRefresh = new ConcurrentHashMap<>();
+
+    public void refresh(FluxCacheRefreshContext ctx) {
+        // todo implement the refresh logic here
+        loadThenSwap(ctx);
+
+    }
+
+    private void loadThenSwap(FluxCacheRefreshContext ctx) {
+        for (Object key : ctx.getKeys()) {
+            if (!shouldRefreshKey(key, ctx))
+                continue;
+
+            Object newValue = safeInvokeLoader(ctx, key);
+            putValue(ctx.getCache(), key, newValue, ctx.getRefreshConfig());
+        }
+    }
+
+    private void putValue(FluxCache cache, Object key, Object value, FluxRefresh config) {
+        cache.put(key, value);
+    }
+
+    // todo 扩展可以实现单个key刷新间隔
+    private boolean shouldRefreshKey(Object key, FluxCacheRefreshContext ctx) {
+        return true;
+    }
+
+    private Object safeInvokeLoader(FluxCacheRefreshContext ctx, Object key) {
+        try {
+            FluxForceRefreshContext.enable();
+            return invokeLoader(ctx.getBean(), ctx.getMethod(), key);
+        } catch (InvocationTargetException e) {
+            Throwable target = e.getTargetException();
+            log.error("[FluxCache] 加载 key={} 失败 targetEx={}", key, target.toString());
+        } catch (Exception e) {
+            FluxForceRefreshContext.disable();
+            log.error("[FluxCache] 加载 key={} 失败 ex={}", key, e.toString());
+        }
+        return null;
+    }
+
+    private Object invokeLoader(Object bean, Method method, Object key)
+        throws InvocationTargetException, IllegalAccessException {
+        ReflectionUtils.makeAccessible(method);
+        if (method.getParameterCount() == 0) {
+            return method.invoke(bean);
+        } else if (method.getParameterCount() == 1) {
+            return method.invoke(bean, key);
+        } else {
+            throw new IllegalStateException("不支持多参数刷新: " + method);
+        }
+    }
+}

--- a/fluxcache-core/src/main/java/com/fluxcache/core/preheat/FluxForceRefreshContext.java
+++ b/fluxcache-core/src/main/java/com/fluxcache/core/preheat/FluxForceRefreshContext.java
@@ -1,0 +1,55 @@
+package com.fluxcache.core.preheat;
+
+/**
+ * @author : wh
+ * @date : 2025/8/12
+ * @description:
+ */
+public class FluxForceRefreshContext {
+
+    private static final ThreadLocal<Boolean> FORCE = ThreadLocal.withInitial(() -> Boolean.FALSE);
+
+    private FluxForceRefreshContext() {
+    }
+
+    public static void enable() {
+        FORCE.set(Boolean.TRUE);
+    }
+
+    public static void disable() {
+        FORCE.remove();
+    }
+
+    public static boolean isForceRefresh() {
+        return FORCE.get();
+    }
+
+    /**
+     * 包装一个 Runnable 在强制刷新模式下执行。
+     */
+    public static void runWithForce(Runnable runnable) {
+        enable();
+        try {
+            runnable.run();
+        } finally {
+            disable();
+        }
+    }
+
+    /**
+     * 包装一个返回值逻辑在强制刷新模式下执行。
+     */
+    public static <T> T callWithForce(java.util.concurrent.Callable<T> callable) {
+        enable();
+        try {
+            return callable.call();
+        } catch (RuntimeException re) {
+            throw re;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        } finally {
+            disable();
+        }
+    }
+
+}

--- a/fluxcache-core/src/main/java/com/fluxcache/core/preheat/FluxPreheatDataProvider.java
+++ b/fluxcache-core/src/main/java/com/fluxcache/core/preheat/FluxPreheatDataProvider.java
@@ -1,0 +1,27 @@
+package com.fluxcache.core.preheat;
+
+import java.util.Collection;
+
+/**
+ * @author : wh
+ * @date : 2025/8/11
+ * @description:
+ */
+@FunctionalInterface
+public interface FluxPreheatDataProvider<T> {
+
+    /**
+     * 获取用于预热的参数数据集合
+     *
+     * @return 一个包含预热所需参数的集合
+     */
+    Collection<T> getPreheatData();
+
+    final class None<T> implements FluxPreheatDataProvider<T> {
+        @Override
+        public Collection<T> getPreheatData() {
+            return null;
+        }
+    }
+
+}

--- a/fluxcache-core/src/main/java/com/fluxcache/core/preheat/FluxRefreshTaskRegistrar.java
+++ b/fluxcache-core/src/main/java/com/fluxcache/core/preheat/FluxRefreshTaskRegistrar.java
@@ -1,0 +1,317 @@
+package com.fluxcache.core.preheat;
+
+import com.fluxcache.core.FluxCache;
+import com.fluxcache.core.FluxCacheManager;
+import com.fluxcache.core.annotation.FluxCacheable;
+import com.fluxcache.core.annotation.FluxRefresh;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.ObjectUtils;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.core.MethodIntrospector;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.support.CronTrigger;
+import org.springframework.util.ReflectionUtils;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * @author : wh
+ * @date : 2025/8/11
+ * @description:
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class FluxRefreshTaskRegistrar implements ApplicationListener<ContextRefreshedEvent> {
+
+    private static final String PREHEAT_LOCK_PREFIX = "flux-cache:preheat-lock:";
+
+    private static final String REFRESH_LOCK_PREFIX = "flux-cache:refresh-lock:";
+
+    private final ApplicationContext context;
+
+    private final TaskScheduler taskScheduler;
+
+    private final FluxCacheManager cacheManager;
+
+    private final RedissonClient redissonClient;
+
+    private final FluxCacheRefreshExecutor executor;
+
+    @Override
+    public void onApplicationEvent(ContextRefreshedEvent event) {
+
+        // 只在根上下文执行
+        if (Objects.nonNull(event.getApplicationContext().getParent())) {
+            return;
+        }
+
+        log.info("[FluxCache] 开始扫描 @FluxCacheable 以注册预热与刷新任务");
+
+        String[] beanNames = context.getBeanDefinitionNames();
+        AtomicInteger methodCount = new AtomicInteger();
+
+        for (String beanName : beanNames) {
+            Object beanProxy = context.getBean(beanName);
+            Class<?> targetClass = AopUtils.getTargetClass(beanProxy);
+            if (shouldSkipClass(targetClass)) {
+                continue;
+            }
+
+            Map<Method, FluxCacheable> annotatedMethods =
+                    MethodIntrospector.selectMethods(targetClass,
+                            (MethodIntrospector.MetadataLookup<FluxCacheable>) m ->
+                                    AnnotatedElementUtils.findMergedAnnotation(m, FluxCacheable.class));
+
+            annotatedMethods.forEach((targetMethod, cacheable) -> {
+                if (Objects.isNull(cacheable)) {
+                    return;
+                }
+
+                FluxRefresh refresh = cacheable.refresh();
+                if (refresh == null || !refresh.enabled()) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("[FluxCache] 方法 {}#{} 未启用刷新", targetClass.getSimpleName(), targetMethod.getName());
+                    }
+                    return;
+                }
+                // 获取可在代理对象上调用的方法（避免 JDK 动态代理问题）
+                Method invocableMethod = AopUtils.selectInvocableMethod(targetMethod, beanProxy.getClass());
+
+                // 预热
+                if (refresh.preheatOnStartup()) {
+                    scheduleOneTime(() -> runRefresh(beanProxy, invocableMethod, cacheable.cacheName(), refresh, PREHEAT_LOCK_PREFIX), refresh, invocableMethod, cacheable.cacheName());
+                }
+                // 定时刷新
+                scheduleRecurring(() -> runRefresh(beanProxy, invocableMethod, cacheable.cacheName(), refresh, REFRESH_LOCK_PREFIX), refresh, invocableMethod, cacheable.cacheName());
+                methodCount.getAndIncrement();
+
+            });
+        }
+        log.info("[FluxCache] 缓存刷新任务注册完成，共处理 {} 个方法", methodCount.get());
+
+    }
+
+    private void scheduleRecurring(Runnable task, FluxRefresh refresh, Method method, String cacheName) {
+        Instant startTime = Instant.now()
+                .plus(Duration.of(refresh.initialDelay(), refresh.unit().toChronoUnit()))
+                .plus(jitter(refresh));
+
+        if (ObjectUtils.isNotEmpty(refresh.cron())) {
+            ZoneId zone = ZoneId.systemDefault();
+            taskScheduler.schedule(task, new CronTrigger(refresh.cron(), zone));
+            log.info("[FluxCache] 注册 CRON 刷新 cron={} zone={} method={} cache={}",
+                    refresh.cron(), zone, method.getName(), cacheName);
+        } else if (refresh.fixedRate() > 0) {
+            Duration period = Duration.of(refresh.fixedRate(), refresh.unit().toChronoUnit());
+            taskScheduler.scheduleAtFixedRate(task, startTime, period);
+            log.info("[FluxCache] 注册 fixedRate 刷新 initialDelay={}ms rate={}ms method={} cache={}",
+                    Duration.between(Instant.now(), startTime).toMillis(), period.toMillis(),
+                    method.getName(), cacheName);
+        } else if (refresh.fixedDelay() > 0) {
+            Duration delay = Duration.of(refresh.fixedDelay(), refresh.unit().toChronoUnit());
+            taskScheduler.scheduleWithFixedDelay(task, startTime, delay);
+            log.info("[FluxCache] 注册 fixedDelay 刷新 initialDelay={}ms delay={}ms method={} cache={}",
+                    Duration.between(Instant.now(), startTime).toMillis(), delay.toMillis(),
+                    method.getName(), cacheName);
+        } else {
+            log.warn("[FluxCache] 未找到有效调度参数 (cron/fixedRate/fixedDelay 全空) method={} cache={}",
+                    method.getName(), cacheName);
+        }
+    }
+
+    private void scheduleOneTime(Runnable r, FluxRefresh cfg, Method method, String cacheName) {
+        Instant start = Instant.now().plus(jitter(cfg));
+        taskScheduler.schedule(r, start);
+        log.info("[FluxCache] 注册启动预热任务 method={} cache={} startAt={}", method.getName(), cacheName, start);
+    }
+
+    private void runRefresh(Object bean, Method method, String cacheName, FluxRefresh cfg, String prefix) {
+        try {
+            Collection<?> keys = context.getBean(cfg.provider()).getPreheatData();
+            if (keys == null || keys.isEmpty())
+                return;
+            FluxCacheRefreshContext ctx = FluxCacheRefreshContext.builder()
+                    .bean(bean)
+                    .method(method)
+                    .cacheName(cacheName)
+                    .refreshConfig(cfg)
+                    .cache(cacheManager.getCache(cacheName))
+                    .keys(keys)
+                    .build();
+            withDistributedLockIfNeeded(buildLockKey(prefix, bean, method, cacheName), cfg, () -> executor.refresh(ctx));
+        } catch (Exception e) {
+            log.error("[FluxCache] 执行刷新异常 method={} cache={}", method.getName(), cacheName, e);
+        }
+    }
+
+    private void withDistributedLockIfNeeded(String key, FluxRefresh fluxRefresh, Runnable body) {
+        if (!fluxRefresh.distributedLock()) {
+            body.run();
+            return;
+        }
+
+        try {
+            var lock = redissonClient.getLock(key);
+            if (lock.tryLock(fluxRefresh.lockWaitSeconds(), fluxRefresh.lockLeaseSeconds(), TimeUnit.SECONDS)) {
+                try {
+                    body.run();
+                } finally {
+                    if (lock.isHeldByCurrentThread())
+                        lock.unlock();
+                }
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private String buildLockKey(String prefix, Object bean, Method method, String cacheName) {
+        return prefix + bean.getClass().getName() + ":" + method.getName() + ":" + cacheName;
+    }
+
+    private void executeWithOptionalLock(String lockKey,
+                                         FluxRefresh refresh,
+                                         Runnable taskBody) {
+        if (!refresh.distributedLock()) {
+            taskBody.run();
+            return;
+        }
+        RLock lock = redissonClient.getLock(lockKey);
+
+        // todo maybe use properties to get default values
+        long waitSeconds = refresh.lockWaitSeconds();
+        long leaseSeconds = refresh.lockLeaseSeconds();
+
+        boolean locked = false;
+        try {
+            locked = lock.tryLock(waitSeconds, leaseSeconds, TimeUnit.SECONDS);
+            if (!locked) {
+                log.debug("[FluxCache] 获取锁失败 lockKey {} 等待 {}s", lockKey, waitSeconds);
+                return;
+            }
+            log.debug("[FluxCache] 获取锁成功 lockKey {}", lockKey);
+            taskBody.run();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.error("[FluxCache] 尝试获取锁被中断 lockKey {}", lockKey, e);
+        } catch (Exception ex) {
+            log.error("[FluxCache] 分布式锁执行异常 lockKey {}", lockKey, ex);
+        } finally {
+            if (locked && lock.isHeldByCurrentThread()) {
+                try {
+                    lock.unlock();
+                } catch (Exception unlockEx) {
+                    log.error("[FluxCache] 释放锁异常 lockKey {}", lockKey, unlockEx);
+                }
+            }
+        }
+    }
+
+    private void executeRefreshLogic(Object beanProxy,
+                                     Method method,
+                                     String cacheName,
+                                     FluxRefresh refresh,
+                                     boolean startupPreheat) {
+
+        long startNanos = System.nanoTime();
+        boolean success = true;
+        int keyCount = 0;
+        Throwable error = null;
+
+        try {
+            FluxPreheatDataProvider<?> provider = context.getBean(refresh.provider());
+
+            Collection<?> keys;
+            try {
+                keys = provider.getPreheatData();
+            } catch (Exception providerEx) {
+                log.error("[FluxCache] provider 获取预热数据异常 provider={} method={} cache={}",
+                        refresh.provider().getSimpleName(), method.getName(), cacheName, providerEx);
+                return;
+            }
+
+            if (keys == null || keys.isEmpty()) {
+                log.debug("[FluxCache] 无可刷新 key method={} cache={}", method.getName(), cacheName);
+                return;
+            }
+
+            keyCount = keys.size();
+
+            FluxCache cache = cacheManager.getCache(cacheName);
+            if (cache == null) {
+                log.error("[FluxCache] 找不到缓存 cacheName={} method={}", cacheName, method.getName());
+                return;
+            }
+
+            // todo 刷新策略 可扩展：EVICT_BATCH、PARALLEL、PUT_DIRECT 等
+            for (Object key : keys) {
+                invokeMethodForKey(beanProxy, method, key);
+            }
+
+            log.info("[FluxCache] 刷新完成 cache={} method={} keys={} startupPreheat={}",
+                    cacheName, method.getName(), keyCount, startupPreheat);
+
+        } catch (Throwable t) {
+            success = false;
+            error = t;
+            log.error("[FluxCache] 刷新执行异常 cache={} method={}", cacheName, method.getName(), t);
+        } finally {
+            long costMs = (System.nanoTime() - startNanos) / 1_000_000;
+            // metrics 占位：可接入 Micrometer
+            // metricsRecorder.record(cacheName, method, success, keyCount, costMs);
+            if (log.isDebugEnabled()) {
+                log.debug("[FluxCache] 刷新统计 cache={} method={} success={} keys={} cost={}ms error={}",
+                        cacheName, method.getName(), success, keyCount, costMs,
+                        (error == null ? "N/A" : error.getClass().getSimpleName()));
+            }
+        }
+    }
+
+    private void invokeMethodForKey(Object beanProxy, Method method, Object key)
+            throws InvocationTargetException, IllegalAccessException {
+        ReflectionUtils.makeAccessible(method);
+        if (method.getParameterCount() == 0) {
+            method.invoke(beanProxy);
+        } else if (method.getParameterCount() == 1) {
+            method.invoke(beanProxy, key);
+        } else {
+            log.warn("[FluxCache] 暂不支持多参数刷新 method={} 参数个数={}", method.getName(), method.getParameterCount());
+        }
+    }
+
+    private boolean shouldSkipClass(Class<?> clazz) {
+        String pkg = clazz.getPackage() != null ? clazz.getPackage().getName() : "";
+        return pkg.startsWith("org.springframework.") ||
+                pkg.startsWith("java.") ||
+                pkg.startsWith("jakarta.") ||
+                pkg.startsWith("sun.");
+    }
+
+    /**
+     * 计算抖动 (jitter) 用于错峰
+     */
+    private Duration jitter(FluxRefresh refresh) {
+        long boundMs = refresh.jitterMillis();
+        if (boundMs <= 0)
+            return Duration.ZERO;
+        long rand = ThreadLocalRandom.current().nextLong(boundMs);
+        return Duration.ofMillis(rand);
+    }
+}

--- a/fluxcache-core/src/main/java/com/fluxcache/core/properties/FluxCacheProperties.java
+++ b/fluxcache-core/src/main/java/com/fluxcache/core/properties/FluxCacheProperties.java
@@ -94,7 +94,11 @@ public class FluxCacheProperties {
      * @return
      */
     public FluxCacheLevel fluxCacheLevel(FluxCacheLevel cacheLevel) {
-        return Objects.equals(cacheLevel, FluxCacheLevel.NULL) ? this.defaultCacheLevel : cacheLevel;
+        if (Objects.isNull(cacheLevel) || Objects.equals(cacheLevel, FluxCacheLevel.NULL)) {
+            return this.defaultCacheLevel;
+        }
+        return cacheLevel;
+        
     }
 
     public String namespace() {

--- a/fluxcache-core/src/main/java/com/fluxcache/core/properties/FluxCacheProperties.java
+++ b/fluxcache-core/src/main/java/com/fluxcache/core/properties/FluxCacheProperties.java
@@ -2,13 +2,14 @@ package com.fluxcache.core.properties;
 
 import com.fluxcache.core.enums.FluxCacheLevel;
 import com.fluxcache.core.enums.FluxCacheType;
-import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 import lombok.Data;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.util.ObjectUtils;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 import static com.fluxcache.core.properties.FluxCacheProperties.FLUX_CACHE;
 
@@ -26,6 +27,7 @@ public class FluxCacheProperties {
     @Value("${spring.application.name}")
     private String applicationName;
 
+
     private String namespace;
 
     /**
@@ -42,6 +44,17 @@ public class FluxCacheProperties {
      * 是否开启异步监控
      */
     private boolean asyncMonitorEnable = true;
+
+    /**
+     * 是否缓存null
+     */
+    private boolean allowCacheNull = true;
+
+    /**
+     * 是否缓存Optional.empty()
+     */
+    private boolean allowCacheEmptyOptional = true;
+
 
     @NestedConfigurationProperty
     private FirstCacheConfig firstCache;
@@ -71,7 +84,7 @@ public class FluxCacheProperties {
          */
         private TimeUnit timeUnit = TimeUnit.MINUTES;
 
-        private FluxCacheType fluxCacheType;
+        private FluxCacheType cacheType;
 
     }
 
@@ -80,8 +93,8 @@ public class FluxCacheProperties {
      *
      * @return
      */
-    public FluxCacheLevel fluxCacheLevel(FluxCacheLevel fluxCacheLevel) {
-        return Objects.equals(fluxCacheLevel, FluxCacheLevel.NULL) ? this.defaultCacheLevel : fluxCacheLevel;
+    public FluxCacheLevel fluxCacheLevel(FluxCacheLevel cacheLevel) {
+        return Objects.equals(cacheLevel, FluxCacheLevel.NULL) ? this.defaultCacheLevel : cacheLevel;
     }
 
     public String namespace() {

--- a/fluxcache-core/src/main/resources/META-INF/spring.factories
+++ b/fluxcache-core/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-    com.fluxcache.core.DefaultFluxCacheManager

--- a/fluxcache-core/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/fluxcache-core/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.fluxcache.core.DefaultFluxCacheManager

--- a/fluxcache-example/src/main/java/com/fluxcache/example/config/ManuallyRefreshCache.java
+++ b/fluxcache-example/src/main/java/com/fluxcache/example/config/ManuallyRefreshCache.java
@@ -1,0 +1,45 @@
+package com.fluxcache.example.config;
+
+import com.fluxcache.core.FluxCache;
+import com.fluxcache.core.FluxCacheManager;
+import com.fluxcache.example.utils.RandomDataUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author : wh
+ * @date : 2025/9/16 14:32
+ * @description:
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ManuallyRefreshCache implements ApplicationListener<ContextRefreshedEvent> {
+
+    private final FluxCacheManager cacheManager;
+
+    public static final String KEY = "ManuallyRefreshCache";
+
+    @Override
+    public void onApplicationEvent(ContextRefreshedEvent event) {
+        // 获取key
+
+        new Thread(() -> {
+            while (true) {
+                FluxCache<Object, Object> cache = cacheManager.getCache(MyFluxCacheDataRegistered.PRODUCT_MANUAL_MultiLevel_CACHE);
+                cache.put(KEY, RandomDataUtils.randomStudents());
+                try {
+                    TimeUnit.SECONDS.sleep(2);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }).start();
+
+    }
+}

--- a/fluxcache-example/src/main/java/com/fluxcache/example/config/MyFluxCacheDataRegistered.java
+++ b/fluxcache-example/src/main/java/com/fluxcache/example/config/MyFluxCacheDataRegistered.java
@@ -3,12 +3,13 @@ package com.fluxcache.example.config;
 import com.fluxcache.core.enums.FluxCacheLevel;
 import com.fluxcache.core.enums.FluxCacheType;
 import com.fluxcache.core.manual.FluxCacheDataRegistered;
-import com.fluxcache.core.model.FluxCacheCacheableConfig;
+import com.fluxcache.core.model.FluxCacheConfig;
 import com.fluxcache.core.model.FluxMultilevelCacheCacheable;
+import org.springframework.stereotype.Component;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import org.springframework.stereotype.Component;
 
 /**
  * @author : wh
@@ -29,72 +30,72 @@ public class MyFluxCacheDataRegistered implements FluxCacheDataRegistered {
     @Override
     public List<FluxMultilevelCacheCacheable> registerCache() {
         List<FluxMultilevelCacheCacheable> cacheables = new ArrayList<>();
-        FluxCacheCacheableConfig build = new FluxCacheCacheableConfig.Builder()
-            .setCacheType(FluxCacheType.CAFFEINE)
-            .setMaxSize(100)
-            .setTtl(10L)
-            .setInitSize(10)
-            .setUnit(TimeUnit.SECONDS)
-            .build();
+        FluxCacheConfig build = new FluxCacheConfig.Builder()
+                .setCacheType(FluxCacheType.CAFFEINE)
+                .setMaxSize(100)
+                .setTtl(10L)
+                .setInitSize(10)
+                .setUnit(TimeUnit.SECONDS)
+                .build();
 
         FluxMultilevelCacheCacheable cacheable = new FluxMultilevelCacheCacheable.CacheConfigBuilder()
-            .setCacheName(PRODUCT_MANUAL_CACHE)
-            .setFluxCacheLevel(FluxCacheLevel.FirstCacheable)
-            .setFirstCacheConfig(build)
-            .build();
+                .setCacheName(PRODUCT_MANUAL_CACHE)
+                .setFluxCacheLevel(FluxCacheLevel.FirstCacheable)
+                .setFirstCacheConfig(build)
+                .build();
 
 
-        FluxCacheCacheableConfig build1 = new FluxCacheCacheableConfig.Builder()
-            .setCacheType(FluxCacheType.CAFFEINE)
-            .setMaxSize(100)
-            .setTtl(10L)
-            .setInitSize(10)
-            .setUnit(TimeUnit.SECONDS)
-            .build();
+        FluxCacheConfig build1 = new FluxCacheConfig.Builder()
+                .setCacheType(FluxCacheType.CAFFEINE)
+                .setMaxSize(100)
+                .setTtl(10L)
+                .setInitSize(10)
+                .setUnit(TimeUnit.SECONDS)
+                .build();
 
-        FluxCacheCacheableConfig build2 = new FluxCacheCacheableConfig.Builder()
-            .setCacheType(FluxCacheType.REDIS_R_MAP)
-            .setMaxSize(100)
-            .setTtl(10L)
-            .setInitSize(10)
-            .setUnit(TimeUnit.SECONDS)
-            .build();
+        FluxCacheConfig build2 = new FluxCacheConfig.Builder()
+                .setCacheType(FluxCacheType.REDIS_R_MAP)
+                .setMaxSize(100)
+                .setTtl(10L)
+                .setInitSize(10)
+                .setUnit(TimeUnit.SECONDS)
+                .build();
 
 
         FluxMultilevelCacheCacheable cacheable1 = new FluxMultilevelCacheCacheable.CacheConfigBuilder()
-            .setCacheName(PRODUCT_MANUAL_MultiLevel_CACHE)
-            .setFluxCacheLevel(FluxCacheLevel.SecondaryCacheable)
-            .setFirstCacheConfig(build1)
-            .setSecondaryCacheConfig(build2)
-            .build();
+                .setCacheName(PRODUCT_MANUAL_MultiLevel_CACHE)
+                .setFluxCacheLevel(FluxCacheLevel.SecondaryCacheable)
+                .setFirstCacheConfig(build1)
+                .setSecondaryCacheConfig(build2)
+                .build();
 
-        FluxCacheCacheableConfig RedisFirst = new FluxCacheCacheableConfig.Builder()
-            .setCacheType(FluxCacheType.REDIS_R_MAP)
-            .setMaxSize(100)
-            .setTtl(10L)
-            .setInitSize(10)
-            .setUnit(TimeUnit.SECONDS)
-            .build();
+        FluxCacheConfig RedisFirst = new FluxCacheConfig.Builder()
+                .setCacheType(FluxCacheType.REDIS_R_MAP)
+                .setMaxSize(100)
+                .setTtl(10L)
+                .setInitSize(10)
+                .setUnit(TimeUnit.SECONDS)
+                .build();
 
         FluxMultilevelCacheCacheable redisFirstCacheable = new FluxMultilevelCacheCacheable.CacheConfigBuilder()
-            .setCacheName(PRODUCT_Redis_First_CACHE)
-            .setFluxCacheLevel(FluxCacheLevel.FirstCacheable)
-            .setFirstCacheConfig(RedisFirst)
-            .build();
+                .setCacheName(PRODUCT_Redis_First_CACHE)
+                .setFluxCacheLevel(FluxCacheLevel.FirstCacheable)
+                .setFirstCacheConfig(RedisFirst)
+                .build();
 
-        FluxCacheCacheableConfig localFirst = new FluxCacheCacheableConfig.Builder()
-            .setCacheType(FluxCacheType.CAFFEINE)
-            .setMaxSize(100)
-            .setTtl(10L)
-            .setInitSize(10)
-            .setUnit(TimeUnit.SECONDS)
-            .build();
+        FluxCacheConfig localFirst = new FluxCacheConfig.Builder()
+                .setCacheType(FluxCacheType.CAFFEINE)
+                .setMaxSize(100)
+                .setTtl(10L)
+                .setInitSize(10)
+                .setUnit(TimeUnit.SECONDS)
+                .build();
 
         FluxMultilevelCacheCacheable localFirstCacheable = new FluxMultilevelCacheCacheable.CacheConfigBuilder()
-            .setCacheName(PRODUCT_LOCAL_FIRST_CACHE)
-            .setFluxCacheLevel(FluxCacheLevel.FirstCacheable)
-            .setFirstCacheConfig(localFirst)
-            .build();
+                .setCacheName(PRODUCT_LOCAL_FIRST_CACHE)
+                .setFluxCacheLevel(FluxCacheLevel.FirstCacheable)
+                .setFirstCacheConfig(localFirst)
+                .build();
 
         cacheables.add(cacheable);
         cacheables.add(cacheable1);

--- a/fluxcache-example/src/main/java/com/fluxcache/example/controller/TestController.java
+++ b/fluxcache-example/src/main/java/com/fluxcache/example/controller/TestController.java
@@ -14,13 +14,6 @@ import com.fluxcache.core.enums.FluxCacheType;
 import com.fluxcache.example.config.MyFluxCacheDataRegistered;
 import com.fluxcache.example.vo.StudentVO;
 import com.google.common.collect.Lists;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomUtils;
@@ -29,6 +22,14 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 /**
  * @author : wh
@@ -309,7 +310,7 @@ public class TestController {
 
     private List<StudentVO> mockSelectSql() {
         log.info("开始查询数据");
-        return Lists.newArrayList(new StudentVO(1L, "小奏技术", RandomUtils.nextInt(1, 1000)), new StudentVO(2L, "小奏技术1", RandomUtils.nextInt(1, 1000)));
+        return Lists.newArrayList(new StudentVO(1L, "小奏技术", RandomUtils.nextInt(1, 1000)), new StudentVO(2L, "小奏技术1", RandomUtils.nextInt(1, 10000)));
     }
 
     private List<StudentVO> mockSelectSqlToNull() {
@@ -319,7 +320,6 @@ public class TestController {
 
     private Optional<List<StudentVO>> mockSelectSqlAndOptional() {
         log.info("开始查询数据");
-        return Optional.of(Lists.newArrayList(new StudentVO(1L, "小奏技术", RandomUtils.nextInt(1, 1000)), new StudentVO(2L, "小奏技术1", RandomUtils.nextInt(1, 1000))));
-    }
+        return Optional.of(Lists.newArrayList(new StudentVO(1L, "小奏技术", RandomUtils.nextInt(1, 1000)), new StudentVO(2L, "小奏技术1", RandomUtils.nextInt(1, 10000))));    }
 
 }

--- a/fluxcache-example/src/main/java/com/fluxcache/example/controller/TestRefreshCacheController.java
+++ b/fluxcache-example/src/main/java/com/fluxcache/example/controller/TestRefreshCacheController.java
@@ -1,0 +1,40 @@
+package com.fluxcache.example.controller;
+
+import com.fluxcache.core.utils.JsonUtil;
+import com.fluxcache.example.service.StudentProviderService;
+import com.fluxcache.example.vo.StudentVO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * @author : wh
+ * @date : 2025/9/16 14:35
+ * @description:
+ */
+@RestController
+@RequestMapping("/test/refreshCache")
+@Slf4j
+@RequiredArgsConstructor
+public class TestRefreshCacheController {
+
+    private final StudentProviderService studentProviderService;
+
+    @GetMapping("/nullParam")
+    public List<StudentVO> testRefreshCache() {
+        List<StudentVO> vos = studentProviderService.testRefreshCache();
+        log.info("testRefreshCache result: {}", JsonUtil.serialize2Json(vos));
+        return vos;
+    }
+
+/*    @GetMapping("/multiple-keys")
+    public List<StudentVO> testMultipleKeys(String name) {
+        List<StudentVO> vos = studentService.multipleKeys(name);
+        log.info("multiple-keys result: {}", JsonUtil.serialize2Json(vos));
+        return vos;
+    }*/
+}

--- a/fluxcache-example/src/main/java/com/fluxcache/example/service/StudentMultipleKeysProvider.java
+++ b/fluxcache-example/src/main/java/com/fluxcache/example/service/StudentMultipleKeysProvider.java
@@ -1,0 +1,23 @@
+package com.fluxcache.example.service;
+
+import com.fluxcache.core.preheat.FluxPreheatDataProvider;
+import com.google.common.collect.Lists;
+import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+
+/**
+ * @author : wh
+ * @date : 2025/9/16 14:38
+ * @description:
+ */
+@Service
+public class StudentMultipleKeysProvider implements FluxPreheatDataProvider<String> {
+
+    public static final String KEY = "xiaozou";
+
+    @Override
+    public Collection<String> getPreheatData() {
+        return Lists.newArrayList(KEY, "aa", "dd");
+    }
+}

--- a/fluxcache-example/src/main/java/com/fluxcache/example/service/StudentProvider.java
+++ b/fluxcache-example/src/main/java/com/fluxcache/example/service/StudentProvider.java
@@ -1,0 +1,22 @@
+package com.fluxcache.example.service;
+
+import com.fluxcache.core.preheat.FluxPreheatDataProvider;
+import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * @author : wh
+ * @date : 2025/9/16 14:36
+ * @description:
+ */
+@Service
+public class StudentProvider implements FluxPreheatDataProvider<String> {
+
+
+    @Override
+    public Collection<String> getPreheatData() {
+        return List.of("all");
+    }
+}

--- a/fluxcache-example/src/main/java/com/fluxcache/example/service/StudentProviderService.java
+++ b/fluxcache-example/src/main/java/com/fluxcache/example/service/StudentProviderService.java
@@ -1,0 +1,26 @@
+package com.fluxcache.example.service;
+
+import com.fluxcache.example.vo.StudentVO;
+
+import java.util.List;
+
+/**
+ * @author : wh
+ * @date : 2025/9/16 14:35
+ * @description:
+ */
+public interface StudentProviderService {
+
+    /**
+     * 测试缓存刷新
+     * @return
+     */
+    List<StudentVO> testRefreshCache();
+
+
+    /**
+     * 测试缓存刷新
+     * @return
+     */
+    List<StudentVO> refreshCacheByOneParam(String name);
+}

--- a/fluxcache-example/src/main/java/com/fluxcache/example/service/StudentService.java
+++ b/fluxcache-example/src/main/java/com/fluxcache/example/service/StudentService.java
@@ -11,4 +11,7 @@ import java.util.List;
 public interface StudentService {
 
     List<StudentVO> mockSelectSql();
+
+    List<StudentVO> multipleKeys(String name);
+
 }

--- a/fluxcache-example/src/main/java/com/fluxcache/example/service/impl/StudentProviderServiceImpl.java
+++ b/fluxcache-example/src/main/java/com/fluxcache/example/service/impl/StudentProviderServiceImpl.java
@@ -1,0 +1,54 @@
+package com.fluxcache.example.service.impl;
+
+import com.fluxcache.core.annotation.FluxCacheable;
+import com.fluxcache.core.annotation.FluxRefresh;
+import com.fluxcache.example.service.StudentMultipleKeysProvider;
+import com.fluxcache.example.service.StudentProvider;
+import com.fluxcache.example.service.StudentProviderService;
+import com.fluxcache.example.utils.RandomDataUtils;
+import com.fluxcache.example.vo.StudentVO;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * @author : wh
+ * @date : 2025/9/16 14:36
+ * @description:
+ */
+@Service
+@Slf4j
+public class StudentProviderServiceImpl implements StudentProviderService {
+
+    @Override
+    @FluxCacheable(
+            cacheName = "testRefreshCache",
+            key = "'all'",
+            refresh = @FluxRefresh(
+                    enabled = true,
+                    provider = StudentProvider.class,
+                    cron = "0/2 * * * * ?" // 0 */1 * * * ? 一分钟
+            )
+    )
+    public List<StudentVO> testRefreshCache() {
+        log.info("开始查询数据");
+        return RandomDataUtils.randomStudents();
+    }
+
+    @FluxCacheable(
+            cacheName = "refreshCacheByOneParam",
+            key = "#name",
+            refresh = @FluxRefresh(
+                    enabled = true,
+                    provider = StudentMultipleKeysProvider.class,
+                    preheatOnStartup = true,
+                    cron = "0/2 * * * * ?" // 2s刷新一次
+            )
+    )
+    @Override
+    public List<StudentVO> refreshCacheByOneParam(String name) {
+        return RandomDataUtils.randomStudents();
+    }
+
+}

--- a/fluxcache-example/src/main/java/com/fluxcache/example/service/impl/StudentServiceImpl.java
+++ b/fluxcache-example/src/main/java/com/fluxcache/example/service/impl/StudentServiceImpl.java
@@ -1,11 +1,16 @@
 package com.fluxcache.example.service.impl;
 
+import com.fluxcache.core.annotation.FluxCacheable;
+import com.fluxcache.core.annotation.FluxRefresh;
+import com.fluxcache.example.service.StudentMultipleKeysProvider;
 import com.fluxcache.example.service.StudentService;
+import com.fluxcache.example.utils.RandomDataUtils;
 import com.fluxcache.example.vo.StudentVO;
 import com.google.common.collect.Lists;
-import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 /**
  * @author : wh
@@ -21,5 +26,21 @@ public class StudentServiceImpl implements StudentService {
         log.info("开始查询数据");
         List<StudentVO> studentVOS = Lists.newArrayList(new StudentVO(1L, "小奏技术", 18), new StudentVO(2L, "小奏技术1", 19));
         return studentVOS;
+    }
+
+    @Override
+    @FluxCacheable(
+            cacheName = "multipleKeys",
+            key = "#name",
+            refresh = @FluxRefresh(
+                    enabled = true,
+                    provider = StudentMultipleKeysProvider.class,
+                    preheatOnStartup = true,
+                    cron = "0 */1 * * * ?" // 1分钟刷新一次
+            )
+    )
+    public List<StudentVO> multipleKeys(String name) {
+        log.info("开始查询数据");
+        return RandomDataUtils.randomStudents(name);
     }
 }

--- a/fluxcache-example/src/main/java/com/fluxcache/example/utils/RandomDataUtils.java
+++ b/fluxcache-example/src/main/java/com/fluxcache/example/utils/RandomDataUtils.java
@@ -1,0 +1,33 @@
+package com.fluxcache.example.utils;
+
+import com.fluxcache.example.vo.StudentVO;
+import com.google.common.collect.Lists;
+
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * @author : wh
+ * @date : 2025/9/16 14:33
+ * @description:
+ */
+public class RandomDataUtils {
+
+
+    public static List<StudentVO> randomStudents() {
+        return randomStudents("小奏技术");
+    }
+
+    /**
+     * 随机生成学生数据
+     *
+     * @return
+     */
+    public static List<StudentVO> randomStudents(String name) {
+        List<StudentVO> studentVOS = Lists.newArrayList();
+        for (int i = 0; i < 3; i++) {
+            studentVOS.add(new StudentVO((long) i, name + ThreadLocalRandom.current().nextInt(0, 500), ThreadLocalRandom.current().nextInt(0, 500)));
+        }
+        return studentVOS;
+    }
+}

--- a/fluxcache-example/src/test/java/com/fluxcache/example/controller/TestCacheProvider.java
+++ b/fluxcache-example/src/test/java/com/fluxcache/example/controller/TestCacheProvider.java
@@ -1,0 +1,90 @@
+package com.fluxcache.example.controller;
+
+import com.fluxcache.core.FluxCache;
+import com.fluxcache.core.FluxCacheManager;
+import com.fluxcache.example.FluxCacheApplication;
+import com.fluxcache.example.config.ManuallyRefreshCache;
+import com.fluxcache.example.config.MyFluxCacheDataRegistered;
+import com.fluxcache.example.service.StudentMultipleKeysProvider;
+import com.fluxcache.example.service.StudentProviderService;
+import com.fluxcache.example.vo.StudentVO;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author : wh
+ * @date : 2025/9/16 14:39
+ * @description:
+ */
+@SpringBootTest(classes = FluxCacheApplication.class)
+@Slf4j
+@Testcontainers
+public class TestCacheProvider {
+
+    @Container
+    public static GenericContainer<?> redis = new GenericContainer<>(DockerImageName.parse("redis:6.2.6"))
+            .withExposedPorts(6379);
+
+    @DynamicPropertySource
+    static void redisProperties(DynamicPropertyRegistry registry) {
+        registry.add("redis.host", redis::getHost);
+        registry.add("redis.port", () -> redis.getMappedPort(6379).toString());
+        registry.add("redis.password", () -> "");
+    }
+
+    @Autowired
+    private StudentProviderService studentProviderService;
+
+    @Autowired
+    private FluxCacheManager cacheManager;
+
+    @Test
+    public void testRefreshCacheByNoParam() throws Exception {
+        List<StudentVO> vos = studentProviderService.testRefreshCache();
+        List<StudentVO> vos1 = studentProviderService.testRefreshCache();
+        Assertions.assertEquals(vos, vos1);
+
+        TimeUnit.SECONDS.sleep(4);
+        List<StudentVO> newVos = studentProviderService.testRefreshCache();
+        Assertions.assertNotEquals(vos, newVos);
+    }
+
+    @Test
+    public void testRefreshCacheByOneParam() throws Exception {
+        String key = StudentMultipleKeysProvider.KEY;
+        List<StudentVO> vos = studentProviderService.refreshCacheByOneParam(key);
+        List<StudentVO> vos1 = studentProviderService.refreshCacheByOneParam(key);
+        Assertions.assertEquals(vos, vos1);
+
+        TimeUnit.SECONDS.sleep(4);
+        List<StudentVO> newVos = studentProviderService.refreshCacheByOneParam(key);
+        Assertions.assertNotEquals(vos, newVos);
+    }
+
+    @Test
+    public void RefreshCacheByManually() throws Exception {
+        FluxCache<String, List<StudentVO>> cache = cacheManager.getCache(MyFluxCacheDataRegistered.PRODUCT_MANUAL_MultiLevel_CACHE);
+
+        List<StudentVO> vos = cache.get(ManuallyRefreshCache.KEY).get();
+        List<StudentVO> vos1 = cache.get(ManuallyRefreshCache.KEY).get();
+        Assertions.assertEquals(vos, vos1);
+        TimeUnit.SECONDS.sleep(4);
+
+        List<StudentVO> newVos = cache.get(ManuallyRefreshCache.KEY).get();
+        Assertions.assertNotEquals(vos, newVos);
+
+
+    }
+}

--- a/fluxcache-example/src/test/java/com/fluxcache/example/controller/TestControllerTest.java
+++ b/fluxcache-example/src/test/java/com/fluxcache/example/controller/TestControllerTest.java
@@ -1,17 +1,11 @@
 package com.fluxcache.example.controller;
 
 import com.fluxcache.core.DefaultFluxCacheManager;
-import com.fluxcache.core.monitor.FluxCacheInfo;
-import com.fluxcache.core.monitor.FluxCacheStatics;
-import com.fluxcache.core.properties.FluxCacheProperties;
 import com.fluxcache.example.FluxCacheApplication;
+import com.fluxcache.example.service.StudentService;
 import com.fluxcache.example.vo.StudentVO;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -22,9 +16,14 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+
 
 /**
  * @author : wh
@@ -50,7 +49,7 @@ public class TestControllerTest {
     private final static Long SLEEP_TIME = 3L;
 
     @Autowired
-    private FluxCacheProperties cacheProperties;
+    private StudentService studentService;
 
     @Autowired
     private TestController testController;
@@ -66,10 +65,10 @@ public class TestControllerTest {
         List<StudentVO> vos1 = testController.firstCacheByCaffeine("aaa");
         StudentVO vo1 = vos1.get(0);
         int age1 = vo1.getAge();
-        assertEquals(age, age1);
+        Assertions.assertEquals(age, age1);
         List<StudentVO> vos2 = testController.firstCacheByCaffeine("bb");
         StudentVO vo2 = vos2.get(0);
-        assertNotEquals(age, vo2.getAge());
+        Assertions.assertNotEquals(age, vo2.getAge());
     }
 
     @Test
@@ -91,16 +90,18 @@ public class TestControllerTest {
         List<StudentVO> vos = vosOptionals.get();
         Optional<List<StudentVO>> vosOptional1s = testController.firstCacheByCaffeineAndOptional(key);
         List<StudentVO> vos1 = vosOptional1s.get();
-        assertEquals(vos, vos1);
+        Assertions.assertEquals(vos, vos1);
+
 
         testController.clearFirstCacheByCaffeineAndOptional(key);
 
         vosOptionals = testController.firstCacheByCaffeineAndOptional(key);
 
-        assertNotEquals(vosOptionals.get(), vos);
+        Assertions.assertNotEquals(vosOptionals.get(), vos);
+
 
         vosOptional1s = testController.firstCacheByCaffeineAndOptional(key);
-        assertEquals(vosOptionals.get(), vosOptional1s.get());
+        Assertions.assertEquals(vosOptionals.get(), vosOptional1s.get());
 
     }
 
@@ -113,11 +114,12 @@ public class TestControllerTest {
         List<StudentVO> vos1 = testController.firstCacheByRedis("aaa");
         StudentVO vo1 = vos1.get(0);
         int age1 = vo1.getAge();
-        assertEquals(age, age1);
+        Assertions.assertEquals(age, age1);
+
 
         List<StudentVO> vos2 = testController.firstCacheByCaffeine("bb");
         StudentVO vo2 = vos2.get(0);
-        assertNotEquals(age, vo2.getAge());
+        Assertions.assertNotEquals(age, vo2.getAge());
     }
 
     @Test
@@ -131,11 +133,11 @@ public class TestControllerTest {
         List<StudentVO> vos1 = testController.firstCacheByRedisBucket(cacheName);
         StudentVO vo1 = vos1.get(0);
         int age1 = vo1.getAge();
-        assertEquals(age, age1);
+        Assertions.assertEquals(age, age1);
 
         List<StudentVO> vos2 = testController.firstCacheByRedisBucket(cacheNameB);
         StudentVO vo2 = vos2.get(0);
-        assertNotEquals(age, vo2.getAge());
+        Assertions.assertNotEquals(age, vo2.getAge());
 
     }
 
@@ -143,9 +145,11 @@ public class TestControllerTest {
     public void testNullFirstCacheByRedisBucket() {
         String cacheName = "abcd-null-bucket";
         List<StudentVO> vos = testController.firstNullCacheByRedisBucket(cacheName);
-        assertNull(vos);
+        Assertions.assertNull(vos);
+
         List<StudentVO> vos1 = testController.firstNullCacheByRedisBucket(cacheName);
-        assertNull(vos1);
+        Assertions.assertNull(vos1);
+
     }
 
     @Test
@@ -159,7 +163,7 @@ public class TestControllerTest {
         List<StudentVO> vos1 = testController.firstCacheByRedisBucket(cacheName);
         StudentVO vo1 = vos1.get(0);
         int age1 = vo1.getAge();
-        assertEquals(age, age1);
+        Assertions.assertEquals(age, age1);
 
         testController.deleteFirstCacheByRedisBucket(cacheName);
         List<StudentVO> vos2 = testController.firstCacheByRedisBucket(cacheName);
@@ -179,7 +183,7 @@ public class TestControllerTest {
         List<StudentVO> vos1 = testController.firstCacheByRedisBucket(cacheName);
         StudentVO vo1 = vos1.get(0);
         int age1 = vo1.getAge();
-        assertEquals(age, age1);
+        Assertions.assertEquals(age, age1);
 
         testController.deleteFirstCacheByRedisBucket(cacheName);
 
@@ -197,7 +201,7 @@ public class TestControllerTest {
         String name = "orderByNull2";
         List<StudentVO> aNull = testController.mockSelectSqlToNullBySecondaryCache(name);
         List<StudentVO> aNull1 = testController.mockSelectSqlToNullBySecondaryCache(name);
-        assertEquals(aNull, aNull1);
+        Assertions.assertEquals(aNull, aNull1);
     }
 
     @Test
@@ -224,7 +228,7 @@ public class TestControllerTest {
         List<StudentVO> vos3 = testController.firstCacheByCaffeine("aaa");
         StudentVO vo3 = vos3.get(0);
         int age3 = vo3.getAge();
-        assertEquals(age2, age3);
+        Assertions.assertEquals(age2, age3);
     }
 
     @Test
@@ -237,7 +241,7 @@ public class TestControllerTest {
         StudentVO vo1 = vos1.get(0);
         int age1 = vo1.getAge();
 
-        assertEquals(age, age1);
+        Assertions.assertEquals(age, age1);
 
         List<StudentVO> vobs = testController.firstCacheByCaffeine("bbb");
         StudentVO vob = vobs.get(0);
@@ -247,7 +251,7 @@ public class TestControllerTest {
         StudentVO vob1 = vosb1.get(0);
         int ageb1 = vob1.getAge();
 
-        assertEquals(ageb, ageb1);
+        Assertions.assertEquals(ageb, ageb1);
 
         testController.clearFirstCacheByCaffeineByName("firstCacheByCaffeine");
         TimeUnit.SECONDS.sleep(SLEEP_TIME);
@@ -256,12 +260,12 @@ public class TestControllerTest {
         StudentVO vo3 = vos3.get(0);
         int age3 = vo3.getAge();
 
-        assertNotEquals(age, age3);
+        Assertions.assertNotEquals(age, age3);
 
         List<StudentVO> vosb3 = testController.firstCacheByCaffeine("bbb");
         StudentVO vob3 = vosb3.get(0);
         int ageb3 = vob3.getAge();
-        assertNotEquals(ageb, ageb3);
+        Assertions.assertNotEquals(ageb, ageb3);
     }
 
     @Test
@@ -288,13 +292,13 @@ public class TestControllerTest {
         List<StudentVO> bb = testController.firstCacheByCaffeine("aa");
         StudentVO vb = bb.get(0);
         int ageB = vb.getAge();
-        assertEquals(age, ageB);
+        Assertions.assertEquals(age, ageB);
         testController.firstCacheByCaffeinePutCache("aa");
         TimeUnit.SECONDS.sleep(SLEEP_TIME);
         List<StudentVO> cc = testController.firstCacheByCaffeine("aa");
         StudentVO vc = cc.get(0);
         int ageC = vc.getAge();
-        assertNotEquals(age, ageC);
+        Assertions.assertNotEquals(age, ageC);
     }
 
     @Test
@@ -316,7 +320,7 @@ public class TestControllerTest {
         List<StudentVO> vos1 = testController.productManualCache("manualProduct");
         StudentVO vo1 = vos1.get(0);
         int age1 = vo1.getAge();
-        assertEquals(age, age1);
+        Assertions.assertEquals(age, age1);
     }
 
     @Test
@@ -327,16 +331,7 @@ public class TestControllerTest {
         List<StudentVO> vos1 = testController.productManualMultiLevelCache("productId1");
         StudentVO vo1 = vos1.get(0);
         int age1 = vo1.getAge();
-        assertEquals(age, age1);
-    }
-
-    @Test
-    public void testFluxCacheInfo() {
-        List<StudentVO> vos = testController.firstCacheByCaffeine("aaa");
-        List<StudentVO> vos1 = testController.firstCacheByCaffeine("aaa");
-        FluxCacheStatics caffeine = cacheManager.getCacheStatics("firstCacheByCaffeine");
-        LinkedList<FluxCacheInfo> list = caffeine.getFluxCacheInfos();
-
+        Assertions.assertEquals(age, age1);
     }
 
     @Test


### PR DESCRIPTION
https://github.com/weihubeats/fluxcache/issues/13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Scheduled cache refresh support via annotation (cron/fixed rate), optional startup preheat, per-key refresh and distributed locking; ability to list all caches.

- **Documentation**
  - Added a “缓存刷新” guide with usage examples and provider pattern; expanded cache management API docs and cache prefix guidance.

- **Examples**
  - Example app: new refresh demo endpoints, preheat providers, and a manual refresh demo.

- **Tests**
  - Integration tests (Redis/Testcontainers) for scheduled, keyed, and manual refresh flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->